### PR TITLE
fix: correct backend build path in Dockerfile

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -12,4 +12,4 @@ EXPOSE 3000
 
 RUN npm run tsc
 
-CMD ["node", "build/index.js"]
+CMD ["node", "build/src/index.js"]


### PR DESCRIPTION
Change CMD path from build/index.js to build/src/index.js to match actual build output structure