### PR TITLE
fix: restore Promise<Response<Room>> return type in rooms router

### DIFF
--- a/backend/src/routes/roomsRouter.ts
+++ b/backend/src/routes/roomsRouter.ts
@@ -3,42 +3,48 @@ import { Contract, Department, Person, Room, Title } from "../models";
 
 const router = Router();
 
-router.get("/:id", async (req: Request<{ id: string }>, res: Response) => {
-  const room = await Room.findByPk(req.params.id, {
-    attributes: ["id", "name", "area"],
-    include: [
-      {
-        model: Contract,
-        as: "contracts",
-        attributes: ["startDate", "endDate"],
-        include: [
-          {
-            model: Person,
-            as: "person",
-            attributes: ["firstName", "lastName"],
-            include: [
-              {
-                model: Department,
-                as: "department",
-                attributes: ["name"],
-              },
-              {
-                model: Title,
-                as: "title",
-                attributes: ["name"],
-              },
-            ],
-          },
-        ],
-      },
-    ],
-  });
+router.get(
+  "/:id",
+  async (
+    req: Request<{ id: string }>,
+    res: Response,
+  ): Promise<Response<Room>> => {
+    const room = await Room.findByPk(req.params.id, {
+      attributes: ["id", "name", "area"],
+      include: [
+        {
+          model: Contract,
+          as: "contracts",
+          attributes: ["startDate", "endDate"],
+          include: [
+            {
+              model: Person,
+              as: "person",
+              attributes: ["firstName", "lastName"],
+              include: [
+                {
+                  model: Department,
+                  as: "department",
+                  attributes: ["name"],
+                },
+                {
+                  model: Title,
+                  as: "title",
+                  attributes: ["name"],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
 
-  if (!room) {
-    return res.json({ error: "Room not found." });
-  }
+    if (!room) {
+      return res.json({ error: "Room not found." });
+    }
 
-  return res.json(room);
-});
+    return res.json(room);
+  },
+);
 
 export default router;


### PR DESCRIPTION
Restores the `Promise<Response<Room>>` return type annotation that was accidentally removed during faulty merge conflict resolution in commit [`49afaff`](https://github.com/OhTu-Tilasijoittelujarjestelma/Sijoittaja/commit/49afaff87a9c4a3b3e8c9e2ad19e33a7b0159c90).