### PR TITLE
refactor: simplify Redis configuration to use connection URL

### DIFF
--- a/backend/src/config/environmentConfig.ts
+++ b/backend/src/config/environmentConfig.ts
@@ -15,11 +15,7 @@ export const config = {
   sessionSecret: process.env.SESSION_SECRET || "dev-secret-change-this",
   sessionMaxAge: parseInt(process.env.SESSION_MAX_AGE || "86400000"), // 24h
 
-  redis: {
-    host: process.env.REDIS_HOST || "localhost",
-    port: parseInt(process.env.REDIS_PORT || "6379"),
-    password: process.env.REDIS_PASSWORD,
-  },
+  redis: process.env.REDIS_URL || "",
 
   oidc: {
     clientId: process.env.OIDC_CLIENT_ID,

--- a/backend/src/config/sessionConfig.ts
+++ b/backend/src/config/sessionConfig.ts
@@ -23,11 +23,7 @@ const createSessionOptions = async (): Promise<session.SessionOptions> => {
   if (isProduction) {
     console.log("Setting up Redis session store for production");
 
-    const redisClient = new Redis({
-      host: config.redis.host,
-      port: config.redis.port,
-      password: config.redis.password,
-    });
+    const redisClient = new Redis(config.redis);
 
     redisClient.on("error", (err) => console.log("Redis Client Error", err));
     redisClient.on("connect", () => console.log("Connected to Redis"));


### PR DESCRIPTION
Description
<!-- Short description of the changes introduced in the PR -->

Simplified Redis configuration by replacing individual host, port and password fields with a single connection URL string.

Architecture
<!-- Do the changes affect the program architecture -->

Yes, the Redis configuration in environmentConfig.ts now uses a single REDIS_URL connection string instead of separate REDIS_HOST, REDIS_PORT and REDIS_PASSWORD environment variables.

Motive
<!-- Why is this change necessary? -->

Using a single connection URL is a simpler and more standard way to configure Redis connections, reducing the number of environment variables needed.

Testing
<!-- Have tests been added for the changes? --> <!-- If yes, what types of tests? If no, why not? -->

No tests added, as this is a configuration refactor with no changes to business logic.

Documentation
<!-- Have the changes been documented in the GitHub Wiki? --> <!-- If yes, what has been documented? If no, why not? -->

No documentation added yet, as this is a minor configuration change that does not require documentation at this stage.