### PR TITLE
fix: update .env.example to use REDIS_URL

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -10,9 +10,7 @@ FRONTEND_URL=http://localhost:5173
 
 # In production, you should also set the following environment variables:
 # REDIS CONFIGURATION (Production only)
-REDIS_HOST=redis-svc
-REDIS_PORT=6379
-REDIS_PASSWORD=
+REDIS_URL=your-redis-url-here
 
 # OPENID CONNECT (OIDC) CONFIGURATION (Production only)
 OIDC_CLIENT_ID=your-client-id-from-sp-registry


### PR DESCRIPTION
Description
<!-- Short description of the changes introduced in the PR -->

Replaced individual Redis environment variables (REDIS_HOST, REDIS_PORT, REDIS_PASSWORD) with a single REDIS_URL in .env.example.

Architecture
<!-- Do the changes affect the program architecture -->

No, this is a configuration file update to match the existing code change.

Motive
<!-- Why is this change necessary? -->

The .env.example file was not updated when the Redis configuration was changed to use a single REDIS_URL in the code, causing inconsistency between the code and the example configuration.

Testing
<!-- Have tests been added for the changes? --> <!-- If yes, what types of tests? If no, why not? -->

No tests added, as this is a configuration file update with no impact on functionality.

Documentation
<!-- Have the changes been documented in the GitHub Wiki? --> <!-- If yes, what has been documented? If no, why not? -->

No documentation added, as this is a minor configuration file update that does not require documentation.