### PR TITLE
fix: apply room class only to rooms found in database in floor map svg

### DIFF
--- a/frontend/src/components/MainView.tsx
+++ b/frontend/src/components/MainView.tsx
@@ -27,6 +27,7 @@ function MainView() {
           const roomName = element.getAttribute("data-room");
           if (roomName && roomsMap.has(roomName)) {
             element.id = String(roomsMap.get(roomName));
+            element.classList.add("room");
           }
         });
       } catch (error: unknown) {
@@ -43,7 +44,6 @@ function MainView() {
   useEffect(() => {
     const rooms = document.querySelectorAll("path[data-room]");
     rooms.forEach((room) => {
-      room.classList.add("room");
       room.classList.toggle("active", room.id === activeRoomId);
     });
   }, [activeRoomId]);


### PR DESCRIPTION
### Description

Previously, the `room` class was applied to all rooms with a `data-room` attribute in the floor map SVG, regardless of whether the room existed in the database. Now the class is only applied to rooms whose room name matches an entry returned from the database.

### Architecture

No architectural changes. The fix is contained within the existing `mapIdsToRoomElements` function in `MainView.tsx`.

### Motive

Paths without a database entry were being highlighted and made clickable, which was incorrect behavior. Clicking such a room would fail to load any details since no data exists for it.

### Testing

No tests added. The change is a minor frontend conditional check and can be verified manually by inspecting the floor map SVG in the browser.

### Documentation

No documentation changes needed. The change is a bug fix to existing behavior.