### PR TITLE
fix: add missing VITE_API_URL env variable to frontend in e2e workflow

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -44,6 +44,8 @@ jobs:
         PORT: 3000
     - name: start frontend
       run: npm run dev:frontend &
+      env:
+        VITE_API_URL: http://localhost:3000
     - name: Run e2e-tests
       run: npm run test:e2e
 


### PR DESCRIPTION
<!-- Fill the description of each field in place of the ... -->

### Description

Added missing `VITE_API_URL` environment variable to the frontend start step in the e2e workflow.

### Architecture

No architectural changes.

### Motive

The frontend was started without `VITE_API_URL`, causing it to not know
where the backend was running. This caused the floor map e2e tests to
fail in CI while passing locally.

### Testing

No new tests added.

### Documentation

No documentation changes needed.