### PR TITLE
feat: add USE_HY_LOGIN environment variable

### DIFF
--- a/backend/src/config/environmentConfig.ts
+++ b/backend/src/config/environmentConfig.ts
@@ -9,6 +9,7 @@ export const DATABASE_URL =
 
 export const isProduction = process.env.NODE_ENV === "production";
 export const isDevelopment = process.env.NODE_ENV === "development";
+export const useHyLogin = process.env.USE_HY_LOGIN === "true";
 
 export const config = {
   port: parseInt(process.env.PORT || "3000"),

--- a/backend/src/config/oidcConfig.ts
+++ b/backend/src/config/oidcConfig.ts
@@ -8,7 +8,7 @@ import {
   type StrategyVerifyCallbackUserInfo,
 } from "openid-client";
 import passport from "passport";
-import { config, isProduction } from "./environmentConfig";
+import { config, useHyLogin } from "./environmentConfig";
 
 interface UserInfo {
   sub: string;
@@ -43,7 +43,7 @@ const verifyLogin: StrategyVerifyCallbackUserInfo<Express.User, UserInfo> = (
 };
 
 export const configurePassport = async () => {
-  if (!isProduction) {
+  if (!useHyLogin) {
     console.log("Passport OIDC configuration skipped (development mode)");
     return;
   }

--- a/backend/src/config/sessionConfig.ts
+++ b/backend/src/config/sessionConfig.ts
@@ -7,7 +7,7 @@ import { Application } from "express";
 import session from "express-session";
 import Redis from "ioredis";
 import passport from "passport";
-import { config, isProduction } from "./environmentConfig";
+import { config, useHyLogin } from "./environmentConfig";
 
 export const configureSession = async (app: Application): Promise<void> => {
   const sessionOptions = await createSessionOptions();
@@ -20,7 +20,7 @@ export const configureSession = async (app: Application): Promise<void> => {
 };
 
 const createSessionOptions = async (): Promise<session.SessionOptions> => {
-  if (isProduction) {
+  if (useHyLogin) {
     console.log("Setting up Redis session store for production");
 
     const redisClient = new Redis(config.redis);

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -7,6 +7,7 @@ const start = async () => {
   app.listen(config.port, () => {
     console.log(`Server running on port ${config.port}`);
     console.log(`Environment: ${process.env.NODE_ENV || "development"}`);
+    console.log(`Use HY login: ${process.env.USE_HY_LOGIN || "false"}`);
   });
 };
 

--- a/backend/src/middleware/mockAuth.ts
+++ b/backend/src/middleware/mockAuth.ts
@@ -1,4 +1,5 @@
 import { NextFunction, Request, Response } from "express";
+import { useHyLogin } from "../config/environmentConfig";
 
 /**
  * Mock authentication middleware - ONLY FOR DEVELOPMENT PURPOSES!
@@ -22,7 +23,7 @@ export const mockAuthMiddleware = (
   res: Response,
   next: NextFunction,
 ) => {
-  if (process.env.NODE_ENV === "production") {
+  if (useHyLogin) {
     return next();
   }
 

--- a/backend/src/routes/authRoutes.ts
+++ b/backend/src/routes/authRoutes.ts
@@ -1,6 +1,6 @@
 import express, { Request, Response, Router } from "express";
 import passport from "passport";
-import { config, isProduction } from "../config/environmentConfig";
+import { config, useHyLogin } from "../config/environmentConfig";
 import { mockAuthMiddleware } from "../middleware/mockAuth";
 
 const router = Router();
@@ -24,7 +24,7 @@ router.get("/user", (req: Request, res: Response) => {
  * DEVELOMPENT VERSION: Uses mock authentication middleware to log in a test user
  * PRODUCTION VERSION: Redirects to university login page
  */
-if (isProduction) {
+if (useHyLogin) {
   router.get("/login", passport.authenticate("oidc"));
 } else {
   router.get("/login", mockAuthMiddleware, (req: Request, res: Response) => {
@@ -39,7 +39,7 @@ if (isProduction) {
  * In the development version, this does nothing
  * because the mock authentication logs directly in on the /api/login route
  */
-if (isProduction) {
+if (useHyLogin) {
   router.get(
     "/login/callback",
     passport.authenticate("oidc", {


### PR DESCRIPTION
### Description

Added USE_HY_LOGIN environment variable to control whether mock or real OIDC
authentication is used. The flag replaces the previous NODE_ENV === "production"
checks in authentication related files.

### Architecture

The change affects the authentication architecture. USE_HY_LOGIN flag allows using mock authentication in production environment for testing purposes without changing the NODE_ENV to "development".

### Motive

The previous implementation tied the authentication method to NODE_ENV, making it
impossible to use mock authentication in production environment. This was a problem as the OIDC
authentication configuration does not currently work and caused the site to crash.

### Testing

No tests were added for this change. Use of the USE_HY_LOGIN flag was tested manually.

### Documentation

No documentation changes were necessary. 