### PR TITLE
test: add roomdetails unit tests

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,6 +18,7 @@
         "@eslint/js": "^9.39.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/node": "^24.10.1",
         "@types/react": "^19.2.5",
         "@types/react-dom": "^19.2.3",
@@ -1944,6 +1945,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@types/aria-query": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,7 @@
     "@eslint/js": "^9.39.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^24.10.1",
     "@types/react": "^19.2.5",
     "@types/react-dom": "^19.2.3",

--- a/frontend/src/components/RoomDetails.tsx
+++ b/frontend/src/components/RoomDetails.tsx
@@ -24,7 +24,11 @@ function RoomDetails({
     >
       <header className="room-details-header">
         <h1 className="room-details-title">Huone</h1>
-        <X className="room-details-close-button" onClick={handleClose} />
+        <X
+          data-testid="close-room-details-panel"
+          className="room-details-close-button"
+          onClick={handleClose}
+        />
       </header>
       <div className="room-details-avatar">
         <h2 className="room-details-avatar-name">{room.name}</h2>

--- a/frontend/tests/RoomDetails.test.tsx
+++ b/frontend/tests/RoomDetails.test.tsx
@@ -1,10 +1,11 @@
 import "@testing-library/jest-dom";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import RoomDetails from "../src/components/RoomDetails.tsx";
 import type { Room } from "../src/types.ts";
 
-const mockHandleClose = () => vi.fn();
+const mockHandleClose = vi.fn();
 
 const mockRoom: Room = {
   id: 1,
@@ -26,5 +27,14 @@ describe("RoomDetails", () => {
     render(<RoomDetails room={mockRoom} handleClose={mockHandleClose} />);
     expect(screen.getByRole("heading", { name: "Huone" })).toBeDefined();
     expect(screen.getByRole("heading", { name: mockRoom.name })).toBeDefined();
+  });
+
+  it("room details panel can be closed", async () => {
+    const user = userEvent.setup();
+    render(<RoomDetails room={mockRoom} handleClose={mockHandleClose} />);
+
+    await user.click(screen.getByTestId("close-room-details-panel"));
+
+    expect(mockHandleClose).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
### Description

Add unit tests for the RoomDetails component covering three cases:
rendering nothing when no room data is provided, rendering the panel
when room data is provided, and closing the panel via the close button.

### Architecture

No architectural changes.

### Motive

Ensure the RoomDetails component behaves correctly and to catch potential code regressions in the future.

### Testing

Yes, three unit tests were added for the RoomDetails component. 
The @testing-library/user-event library was installed to simulate realistic user interactions.

### Documentation

No documentation changes as there currently is no testing section in the documentation.