### PR TITLE
fix: map text being selected on drag

### DIFF
--- a/frontend/src/components/MainView.css
+++ b/frontend/src/components/MainView.css
@@ -51,6 +51,7 @@
   font-weight: 500;
   font-size: var(--map-font-size, 24px);
   pointer-events: none;
+  user-select: none;
 }
 
 .room-group:has(.room.active) .room-label {


### PR DESCRIPTION
<!-- Fill the description of each field in place of the ... -->

### Description

<!-- Short description of the changes introduced in the PR -->

Fix the room labels being selected when dragging the map.

### Architecture

<!-- Do the changes affect the program architecture -->

No changes.

### Motive

<!-- Why is this change necessary? -->

Previously, when dragging the map, the room label texts would get selected, causing flickering. This change makes moving the map much less distracting.

### Testing

<!-- Have tests been added for the changes? -->
<!-- If yes, what types of tests? If no, why not? -->

No changes.

### Documentation

<!-- Have the changes been documented in the GitHub Wiki? -->
<!-- If yes, what has been documented? If no, why not? -->

No changes.