### PR TITLE
test: add e2e tests for edit person user workflow

### DIFF
--- a/e2e-tests/editperson.spec.ts
+++ b/e2e-tests/editperson.spec.ts
@@ -81,3 +81,30 @@ test("cancelling from confirmation modal keeps the edit person modal open", asyn
 
   await expect(page.locator(".personmodal-content")).toBeVisible();
 });
+
+test("editing and saving person details displays updated info in the room list", async ({
+  page,
+}) => {
+  await openSidePanel(page);
+
+  await page.locator(".edit-person-button").first().click();
+  await expect(page.locator(".personmodal-content")).toBeVisible();
+
+  const firstNameInput = page.locator('input[name="firstName"]');
+  const lastNameInput = page.locator('input[name="lastName"]');
+
+  await firstNameInput.clear();
+  await firstNameInput.fill("Uusi nimi");
+
+  await lastNameInput.clear();
+  await lastNameInput.fill("Uusi sukunimi");
+
+  await page.locator(".personmodal-save-button").click();
+  await page.locator(".confirmation-button", { hasText: "Tallenna" }).click();
+
+  await expect(page.locator(".personmodal-overlay")).not.toBeVisible();
+
+  await expect(page.locator("details .person-name").first()).toContainText(
+    "Uusi nimi Uusi sukunimi",
+  );
+});

--- a/e2e-tests/editperson.spec.ts
+++ b/e2e-tests/editperson.spec.ts
@@ -1,0 +1,21 @@
+import { expect, Page } from "@playwright/test";
+import { test } from "./testHelper";
+
+test.use({ viewport: { width: 1920, height: 1080 } });
+
+async function openSidePanel(page: Page) {
+  await page.locator('[data-room="A210"]').click();
+  await page.waitForSelector(".room-details-button", { state: "visible" });
+}
+
+test("edit person button is visible for each room occupant", async ({
+  page,
+}) => {
+  await openSidePanel(page);
+  const editButtons = page.locator(".edit-person-button");
+
+  const count = await editButtons.count();
+  for (let i = 0; i < count; i++) {
+    await expect(editButtons.nth(i)).toBeVisible();
+  }
+});

--- a/e2e-tests/editperson.spec.ts
+++ b/e2e-tests/editperson.spec.ts
@@ -37,3 +37,17 @@ test("clicking outside edit person modal triggers cancel confirmation dialog", a
 
   await expect(page.locator(".confirmation-title")).toBeVisible();
 });
+
+test("edit person save button is disabled when required fields are empty", async ({
+  page,
+}) => {
+  await openSidePanel(page);
+  await page.locator(".edit-person-button").first().click();
+  await expect(page.locator(".personmodal-content")).toBeVisible();
+
+  const firstNameInput = page.locator('input[name="firstName"]');
+  await firstNameInput.clear();
+
+  const saveButton = page.locator(".personmodal-save-button");
+  await expect(saveButton).toBeDisabled();
+});

--- a/e2e-tests/editperson.spec.ts
+++ b/e2e-tests/editperson.spec.ts
@@ -1,12 +1,7 @@
-import { expect, Page } from "@playwright/test";
-import { test } from "./testHelper";
+import { expect } from "@playwright/test";
+import { test, openSidePanel } from "./testHelper";
 
 test.use({ viewport: { width: 1920, height: 1080 } });
-
-async function openSidePanel(page: Page) {
-  await page.locator('[data-room="A210"]').click();
-  await page.waitForSelector(".room-details-button", { state: "visible" });
-}
 
 test("edit person button is visible for each room occupant", async ({
   page,

--- a/e2e-tests/editperson.spec.ts
+++ b/e2e-tests/editperson.spec.ts
@@ -64,3 +64,20 @@ test("cancelling edit person without saving closes the modal", async ({
 
   await expect(page.locator(".personmodal-overlay")).not.toBeVisible();
 });
+
+test("cancelling from confirmation modal keeps the edit person modal open", async ({
+  page,
+}) => {
+  await openSidePanel(page);
+  await page.locator(".edit-person-button").first().click();
+  await expect(page.locator(".personmodal-content")).toBeVisible();
+
+  const firstNameInput = page.locator('input[name="firstName"]');
+  await firstNameInput.clear();
+  await firstNameInput.fill("Uusi nimi");
+
+  await page.locator(".personmodal-save-button").click();
+  await page.locator(".confirmation-button", { hasText: "Peruuta" }).click();
+
+  await expect(page.locator(".personmodal-content")).toBeVisible();
+});

--- a/e2e-tests/editperson.spec.ts
+++ b/e2e-tests/editperson.spec.ts
@@ -62,6 +62,7 @@ test("cancelling edit person without saving closes the modal", async ({
   await page.locator(".personmodal-close-button").click();
   await page.locator(".confirmation-button", { hasText: "Kyllä" }).click();
 
+  await expect(page.locator(".personmodal-content")).not.toBeVisible();
   await expect(page.locator(".personmodal-overlay")).not.toBeVisible();
 });
 
@@ -102,6 +103,7 @@ test("editing and saving person details displays updated info in the room list",
   await page.locator(".personmodal-save-button").click();
   await page.locator(".confirmation-button", { hasText: "Tallenna" }).click();
 
+  await expect(page.locator(".personmodal-content")).not.toBeVisible();
   await expect(page.locator(".personmodal-overlay")).not.toBeVisible();
 
   await expect(page.locator("details .person-name").first()).toContainText(

--- a/e2e-tests/editperson.spec.ts
+++ b/e2e-tests/editperson.spec.ts
@@ -23,3 +23,17 @@ test("edit person modal opens when edit button is clicked", async ({
   await expect(page.locator(".personmodal-overlay")).toBeVisible();
   await expect(page.locator(".personmodal-content")).toBeVisible();
 });
+
+test("clicking outside edit person modal triggers cancel confirmation dialog", async ({
+  page,
+}) => {
+  await openSidePanel(page);
+  await page.locator(".edit-person-button").first().click();
+
+  // Click on overlay background outside the topbar and modal (top-left corner)
+  await page
+    .locator(".personmodal-overlay")
+    .click({ position: { x: 200, y: 200 } });
+
+  await expect(page.locator(".confirmation-title")).toBeVisible();
+});

--- a/e2e-tests/editperson.spec.ts
+++ b/e2e-tests/editperson.spec.ts
@@ -51,3 +51,16 @@ test("edit person save button is disabled when required fields are empty", async
   const saveButton = page.locator(".personmodal-save-button");
   await expect(saveButton).toBeDisabled();
 });
+
+test("cancelling edit person without saving closes the modal", async ({
+  page,
+}) => {
+  await openSidePanel(page);
+  await page.locator(".edit-person-button").first().click();
+  await expect(page.locator(".personmodal-content")).toBeVisible();
+
+  await page.locator(".personmodal-close-button").click();
+  await page.locator(".confirmation-button", { hasText: "Kyllä" }).click();
+
+  await expect(page.locator(".personmodal-overlay")).not.toBeVisible();
+});

--- a/e2e-tests/editperson.spec.ts
+++ b/e2e-tests/editperson.spec.ts
@@ -14,3 +14,12 @@ test("edit person button is visible for each room occupant", async ({
     await expect(editButtons.nth(i)).toBeVisible();
   }
 });
+
+test("edit person modal opens when edit button is clicked", async ({
+  page,
+}) => {
+  await openSidePanel(page);
+  await page.locator(".edit-person-button").first().click();
+  await expect(page.locator(".personmodal-overlay")).toBeVisible();
+  await expect(page.locator(".personmodal-content")).toBeVisible();
+});

--- a/e2e-tests/removeperson.spec.ts
+++ b/e2e-tests/removeperson.spec.ts
@@ -1,12 +1,7 @@
-import { expect, Page } from "@playwright/test";
-import { test } from "./testHelper";
+import { expect } from "@playwright/test";
+import { test, openSidePanel } from "./testHelper";
 
 test.use({ viewport: { width: 1920, height: 1080 } });
-
-async function openSidePanel(page: Page) {
-  await page.locator('[data-room="A210"]').click();
-  await page.waitForSelector(".room-details-button", { state: "visible" });
-}
 
 test("remove button is visible for each occupant", async ({ page }) => {
   await openSidePanel(page);

--- a/e2e-tests/testHelper.ts
+++ b/e2e-tests/testHelper.ts
@@ -1,4 +1,4 @@
-import { test as base } from "@playwright/test";
+import { Page, test as base } from "@playwright/test";
 
 export const test = base.extend<{ forEachTest: void }>({
   forEachTest: [
@@ -14,3 +14,8 @@ export const test = base.extend<{ forEachTest: void }>({
     { auto: true },
   ], // automatically starts for every test.
 });
+
+export async function openSidePanel(page: Page) {
+  await page.locator('[data-room="A210"]').click();
+  await page.waitForSelector(".room-details-button", { state: "visible" });
+}


### PR DESCRIPTION
### Description

Add end-to-end tests for the edit person user workflow, covering the complete user journey from selecting a room occupant through editing and saving person details or cancelling the operation.

### Architecture

No changes.

### Motive

Add e2e test coverage for the edit person workflow to ensure:
- Users can edit and save person details
- Form validation works correctly
- Modal interactions (closing, cancelling) behave as expected
- Changes persist and display correctly in the room occupants list

### Testing

Added 7 new e2e tests covering:
- Edit button visibility for each room occupant
- Opening edit person modal
- Form validation (disabled save button with empty fields)
- Modal closing via close button
- Closing modal via overlay click triggering confirmation
- Confirmation dialog interactions (save and cancel)
- Persisting and displaying edited person details in the list

Also refactored `openSidePanel` helper to shared test utility to eliminate duplication across test files.

### Documentation

No changes.