### PR TITLE
test: add e2e tests for assigning existing people to rooms

### DIFF
--- a/e2e-tests/personmodal.spec.ts
+++ b/e2e-tests/personmodal.spec.ts
@@ -130,3 +130,15 @@ test("confirming save closes modal and persists person", async ({ page }) => {
     page.getByRole("heading", { name: "Lisää henkilö" }),
   ).not.toBeVisible();
 });
+
+test("searching for existing person returns matching results", async ({
+  page,
+}) => {
+  await openAddPersonModal(page);
+  await page.getByLabel("Hae henkilö:").fill("Ah");
+  await page.waitForSelector(".personform-person-option");
+  await expect(page.locator(".personform-person-option")).toHaveCount(1);
+  await expect(page.locator(".personform-person-option")).toContainText(
+    "Ahmed Ali",
+  );
+});

--- a/e2e-tests/personmodal.spec.ts
+++ b/e2e-tests/personmodal.spec.ts
@@ -25,6 +25,17 @@ async function searchAndSelectExistingPerson(page: Page, name: string) {
   await page.locator(".personform-person-option").first().click();
 }
 
+async function saveAndConfirmPerson(page: Page) {
+  await page
+    .locator(".personmodal-actions")
+    .getByRole("button", { name: "Lisää", exact: true })
+    .click();
+  await page
+    .locator(".confirmation-modal")
+    .getByRole("button", { name: "Tallenna" })
+    .click();
+}
+
 test("person modal can be opened", async ({ page }) => {
   await openAddPersonModal(page);
   await expect(
@@ -124,14 +135,7 @@ test("cancelling save confirmation keeps modal open", async ({ page }) => {
 test("confirming save closes modal and persists person", async ({ page }) => {
   await openAddPersonModal(page);
   await fillRequiredFields(page);
-  await page
-    .locator(".personmodal-actions")
-    .getByRole("button", { name: "Lisää", exact: true })
-    .click();
-  await page
-    .locator(".confirmation-modal")
-    .getByRole("button", { name: "Tallenna" })
-    .click();
+  await saveAndConfirmPerson(page);
   await expect(
     page.getByRole("heading", { name: "Lisää henkilö" }),
   ).not.toBeVisible();
@@ -195,14 +199,7 @@ test("saving existing person without contract dates closes the modal and persist
 }) => {
   await openAddPersonModal(page);
   await searchAndSelectExistingPerson(page, "Ah");
-  await page
-    .locator(".personmodal-actions")
-    .getByRole("button", { name: "Lisää", exact: true })
-    .click();
-  await page
-    .locator(".confirmation-modal")
-    .getByRole("button", { name: "Tallenna" })
-    .click();
+  await saveAndConfirmPerson(page);
   await expect(
     page.getByRole("heading", { name: "Lisää henkilö" }),
   ).not.toBeVisible();
@@ -218,14 +215,7 @@ test("saving existing person with contract dates closes the modal and persists p
   await searchAndSelectExistingPerson(page, "Ah");
   await page.getByLabel("Sopimuksen alku:").fill("2025-06-01");
   await page.getByLabel("Sopimuksen loppu:").fill("2026-06-01");
-  await page
-    .locator(".personmodal-actions")
-    .getByRole("button", { name: "Lisää", exact: true })
-    .click();
-  await page
-    .locator(".confirmation-modal")
-    .getByRole("button", { name: "Tallenna" })
-    .click();
+  await saveAndConfirmPerson(page);
   await expect(
     page.getByRole("heading", { name: "Lisää henkilö" }),
   ).not.toBeVisible();

--- a/e2e-tests/personmodal.spec.ts
+++ b/e2e-tests/personmodal.spec.ts
@@ -142,3 +142,21 @@ test("searching for existing person returns matching results", async ({
     "Ahmed Ali",
   );
 });
+
+test("selecting existing person populates person form fields", async ({
+  page,
+}) => {
+  await openAddPersonModal(page);
+  await page.getByLabel("Hae henkilö:").fill("Ah");
+  await page.waitForSelector(".personform-person-option");
+  await page.locator(".personform-person-option").first().click();
+  await expect(page.getByLabel("Etunimi:")).toHaveValue("Ahmed");
+  await expect(page.getByLabel("Sukunimi:")).toHaveValue("Ali");
+  await expect(page.getByLabel("Osasto:")).toContainText("H523 CS");
+  await expect(page.getByLabel("Työnimike:")).toContainText("professori");
+
+  const supervisorTag = page.locator(".personform-supervisor-tag");
+
+  await expect(supervisorTag).toHaveCount(1);
+  await expect(supervisorTag).toContainText("Päivi Koskinen");
+});

--- a/e2e-tests/personmodal.spec.ts
+++ b/e2e-tests/personmodal.spec.ts
@@ -160,3 +160,22 @@ test("selecting existing person populates person form fields", async ({
   await expect(supervisorTag).toHaveCount(1);
   await expect(supervisorTag).toContainText("Päivi Koskinen");
 });
+
+test("existing person form fields are read-only except contract dates", async ({
+  page,
+}) => {
+  await openAddPersonModal(page);
+  await page.getByLabel("Hae henkilö:").fill("Ah");
+  await page.waitForSelector(".personform-person-option");
+  await page.locator(".personform-person-option").first().click();
+  await expect(page.getByLabel("Etunimi:")).toBeDisabled();
+  await expect(page.getByLabel("Sukunimi:")).toBeDisabled();
+  await expect(page.getByLabel("Osasto:")).toBeDisabled();
+  await expect(page.getByLabel("Työnimike:")).toBeDisabled();
+
+  const supervisorTag = page.locator(".personform-supervisor-tag").first();
+  await expect(supervisorTag.locator("button")).toBeDisabled();
+
+  await expect(page.getByLabel("Sopimuksen alku:")).toBeEnabled();
+  await expect(page.getByLabel("Sopimuksen loppu:")).toBeEnabled();
+});

--- a/e2e-tests/personmodal.spec.ts
+++ b/e2e-tests/personmodal.spec.ts
@@ -210,3 +210,29 @@ test("saving existing person without contract dates closes the modal and persist
     page.locator(".person-name", { hasText: "Ahmed Ali" }),
   ).toBeVisible();
 });
+
+test("saving existing person with contract dates closes the modal and persists person", async ({
+  page,
+}) => {
+  await openAddPersonModal(page);
+  await searchAndSelectExistingPerson(page, "Ah");
+  await page.getByLabel("Sopimuksen alku:").fill("2025-06-01");
+  await page.getByLabel("Sopimuksen loppu:").fill("2026-06-01");
+  await page
+    .locator(".personmodal-actions")
+    .getByRole("button", { name: "Lisää", exact: true })
+    .click();
+  await page
+    .locator(".confirmation-modal")
+    .getByRole("button", { name: "Tallenna" })
+    .click();
+  await expect(
+    page.getByRole("heading", { name: "Lisää henkilö" }),
+  ).not.toBeVisible();
+
+  const personItem = page.locator("details", {
+    has: page.locator(".person-name", { hasText: "Ahmed Ali" }),
+  });
+  await expect(personItem).toContainText("Alkupvm: 2025-06-01");
+  await expect(personItem).toContainText("Loppupvm: 2026-06-01");
+});

--- a/e2e-tests/personmodal.spec.ts
+++ b/e2e-tests/personmodal.spec.ts
@@ -181,3 +181,11 @@ test("existing person form fields are read-only except contract dates", async ({
   await expect(page.getByLabel("Sopimuksen alku:")).toBeEnabled();
   await expect(page.getByLabel("Sopimuksen loppu:")).toBeEnabled();
 });
+
+test("selecting existing person enables save button", async ({ page }) => {
+  await openAddPersonModal(page);
+  await searchAndSelectExistingPerson(page, "Ah");
+  await expect(
+    page.getByRole("button", { name: "Lisää", exact: true }),
+  ).toBeEnabled();
+});

--- a/e2e-tests/personmodal.spec.ts
+++ b/e2e-tests/personmodal.spec.ts
@@ -189,3 +189,24 @@ test("selecting existing person enables save button", async ({ page }) => {
     page.getByRole("button", { name: "Lisää", exact: true }),
   ).toBeEnabled();
 });
+
+test("saving existing person without contract dates closes the modal and persists person", async ({
+  page,
+}) => {
+  await openAddPersonModal(page);
+  await searchAndSelectExistingPerson(page, "Ah");
+  await page
+    .locator(".personmodal-actions")
+    .getByRole("button", { name: "Lisää", exact: true })
+    .click();
+  await page
+    .locator(".confirmation-modal")
+    .getByRole("button", { name: "Tallenna" })
+    .click();
+  await expect(
+    page.getByRole("heading", { name: "Lisää henkilö" }),
+  ).not.toBeVisible();
+  await expect(
+    page.locator(".person-name", { hasText: "Ahmed Ali" }),
+  ).toBeVisible();
+});

--- a/e2e-tests/personmodal.spec.ts
+++ b/e2e-tests/personmodal.spec.ts
@@ -19,6 +19,12 @@ async function fillRequiredFields(page: Page) {
   await page.getByLabel("Sopimuksen loppu:").fill("2026-01-01");
 }
 
+async function searchAndSelectExistingPerson(page: Page, name: string) {
+  await page.getByLabel("Hae henkilö:").fill(name);
+  await page.waitForSelector(".personform-person-option");
+  await page.locator(".personform-person-option").first().click();
+}
+
 test("person modal can be opened", async ({ page }) => {
   await openAddPersonModal(page);
   await expect(
@@ -147,9 +153,7 @@ test("selecting existing person populates person form fields", async ({
   page,
 }) => {
   await openAddPersonModal(page);
-  await page.getByLabel("Hae henkilö:").fill("Ah");
-  await page.waitForSelector(".personform-person-option");
-  await page.locator(".personform-person-option").first().click();
+  await searchAndSelectExistingPerson(page, "Ah");
   await expect(page.getByLabel("Etunimi:")).toHaveValue("Ahmed");
   await expect(page.getByLabel("Sukunimi:")).toHaveValue("Ali");
   await expect(page.getByLabel("Osasto:")).toContainText("H523 CS");
@@ -165,9 +169,7 @@ test("existing person form fields are read-only except contract dates", async ({
   page,
 }) => {
   await openAddPersonModal(page);
-  await page.getByLabel("Hae henkilö:").fill("Ah");
-  await page.waitForSelector(".personform-person-option");
-  await page.locator(".personform-person-option").first().click();
+  await searchAndSelectExistingPerson(page, "Ah");
   await expect(page.getByLabel("Etunimi:")).toBeDisabled();
   await expect(page.getByLabel("Sukunimi:")).toBeDisabled();
   await expect(page.getByLabel("Osasto:")).toBeDisabled();


### PR DESCRIPTION
## Description
Add end-to-end tests for the assign existing people to rooms workflow, covering the complete user journey from searching and selecting existing people through saving with optional contract dates or cancelling.

## Architecture
No changes.

## Motive
Add e2e test coverage for the existing people assignment workflow to ensure:

- Users can search and select existing people
- Read-only enforcement for existing person fields (name, department, title, supervisors)
- Contract dates can be optionally set when assigning to rooms
- Modal interactions (closing, cancelling, saving) behave correctly
- Changes persist and display correctly in the room occupants list

## Testing
Added 6 new e2e tests:

- Searching for existing person returns matching results
- Selecting existing person populates form fields with correct data
- Read-only enforcement for person fields except contract dates
- Save button enabled after selecting existing person
- Saving existing person without contract dates persists in room
- Saving existing person with contract dates persists both person and dates

Also refactored and extracted test helpers:

- `searchAndSelectExistingPerson()` - reusable helper to search and select existing people
- `saveAndConfirmPerson()` - extracted save/confirm dialog flow to eliminate duplication

## Documentation
No changes.