### PR TITLE
feat: add multi-type search to GET /api/people endpoint

### DIFF
--- a/backend/src/routes/peopleRouter.ts
+++ b/backend/src/routes/peopleRouter.ts
@@ -231,14 +231,22 @@ router.get("/", async (req: Request, res: Response) => {
       required: false,
     };
 
-    const findOptions: FindOptions<InferAttributes<Person>> = {
-      include: [
-        supervisorsInclude,
-        "department",
-        "title",
-        "researchGroup",
-        contractsInclude,
+    const sharedIncludes = [
+      "department",
+      "title",
+      "researchGroup",
+      contractsInclude,
+    ];
+
+    const nameSearchWhere = {
+      [Op.or]: [
+        { firstName: { [Op.iLike]: `%${queryStr}%` } },
+        { lastName: { [Op.iLike]: `%${queryStr}%` } },
       ],
+    };
+
+    const findOptions: FindOptions<InferAttributes<Person>> = {
+      include: [supervisorsInclude, ...sharedIncludes],
       order: [
         ["lastName", "ASC"],
         ["firstName", "ASC"],
@@ -248,14 +256,46 @@ router.get("/", async (req: Request, res: Response) => {
     if (queryStr) {
       switch (type) {
         case "supervisorName":
-          supervisorsInclude.where = {
-            [Op.or]: [
-              { firstName: { [Op.iLike]: `%${queryStr}%` } },
-              { lastName: { [Op.iLike]: `%${queryStr}%` } },
+          const supervisorSearchOptions = {
+            ...findOptions,
+            where: nameSearchWhere,
+            include: [
+              ...sharedIncludes,
+              {
+                model: Person,
+                as: "subordinates",
+                through: { attributes: [] },
+                required: true,
+              },
             ],
           };
-          supervisorsInclude.required = true;
-          break;
+
+          const matchingSupervisors = await Person.findAll(
+            supervisorSearchOptions,
+          );
+
+          if (matchingSupervisors.length === 1) {
+            const subordinatesSearchOptions = {
+              ...findOptions,
+              include: [
+                {
+                  model: Person,
+                  as: "supervisors",
+                  through: { attributes: [] },
+                  where: { id: matchingSupervisors[0].id },
+                  required: true,
+                },
+                ...sharedIncludes,
+              ],
+            };
+
+            const subordinates = await Person.findAll(
+              subordinatesSearchOptions,
+            );
+            return res.json(subordinates);
+          }
+
+          return res.json(matchingSupervisors);
 
         case "contractEndDate":
           contractsInclude.where = {
@@ -268,12 +308,7 @@ router.get("/", async (req: Request, res: Response) => {
 
         case "personName":
         default:
-          findOptions.where = {
-            [Op.or]: [
-              { firstName: { [Op.iLike]: `%${queryStr}%` } },
-              { lastName: { [Op.iLike]: `%${queryStr}%` } },
-            ],
-          };
+          findOptions.where = nameSearchWhere;
           break;
       }
     }

--- a/backend/src/routes/peopleRouter.ts
+++ b/backend/src/routes/peopleRouter.ts
@@ -1,4 +1,5 @@
 import { Request, Response, Router } from "express";
+import type { FindOptions } from "sequelize";
 import { Op } from "sequelize";
 import { z } from "zod";
 import { Contract, Person, PersonSupervisor, Room } from "../models";
@@ -201,11 +202,11 @@ router.put(
 
 /**
  * GET /api/people
- * Fetches all people, or searches if query parameter 'q' is provided
- * Query parameter 'q' is used for partial matching on first/last name
+ * Fetches all people, or searches based on query parameter 'q' and 'type'
+ * Supported types: personName (default), supervisorName, contractEndDate
  */
 router.get("/", async (req: Request, res: Response) => {
-  const { q } = req.query;
+  const { q, type } = req.query;
 
   try {
     if (q && typeof q === "string") {
@@ -214,34 +215,82 @@ router.get("/", async (req: Request, res: Response) => {
       }
     }
 
-    const where = q
-      ? {
-          [Op.or]: [
-            { firstName: { [Op.iLike]: `%${q}%` } },
-            { lastName: { [Op.iLike]: `%${q}%` } },
-          ],
-        }
-      : {};
+    const baseSupervisorsInclude = {
+      model: Person,
+      as: "supervisors",
+      through: { attributes: [] },
+    };
 
-    const people = await Person.findAll({
-      where,
+    const baseContractsInclude = {
+      model: Contract,
+      as: "contracts",
+      include: [{ model: Room, as: "room" }],
+    };
+
+    let findOptions: FindOptions = {
       include: [
-        { model: Person, as: "supervisors", through: { attributes: [] } },
+        baseSupervisorsInclude,
         "department",
         "title",
         "researchGroup",
-        {
-          model: Contract,
-          as: "contracts",
-          include: [{ model: Room, as: "room" }],
-        },
+        baseContractsInclude,
       ],
       order: [
         ["lastName", "ASC"],
         ["firstName", "ASC"],
       ],
-    });
+    };
 
+    switch (type) {
+      case "supervisorName":
+        findOptions.include = [
+          {
+            ...baseSupervisorsInclude,
+            where: {
+              [Op.or]: [
+                { firstName: { [Op.iLike]: `%${q}%` } },
+                { lastName: { [Op.iLike]: `%${q}%` } },
+              ],
+            },
+            required: true,
+          },
+          "department",
+          "title",
+          "researchGroup",
+          baseContractsInclude,
+        ];
+        break;
+
+      case "contractEndDate":
+        findOptions.include = [
+          baseSupervisorsInclude,
+          "department",
+          "title",
+          "researchGroup",
+          {
+            ...baseContractsInclude,
+            where: {
+              endDate: {
+                [Op.lte]: q,
+              },
+            },
+            required: true,
+          },
+        ];
+        break;
+
+      case "personName":
+      default:
+        findOptions.where = {
+          [Op.or]: [
+            { firstName: { [Op.iLike]: `%${q}%` } },
+            { lastName: { [Op.iLike]: `%${q}%` } },
+          ],
+        };
+        break;
+    }
+
+    const people = await Person.findAll(findOptions);
     res.json(people);
   } catch (error) {
     console.error("Error fetching people:", error);

--- a/backend/src/routes/peopleRouter.ts
+++ b/backend/src/routes/peopleRouter.ts
@@ -2,6 +2,7 @@ import { Request, Response, Router } from "express";
 import type { FindOptions, InferAttributes } from "sequelize";
 import { Op } from "sequelize";
 import { z } from "zod";
+import { sequelize } from "../db";
 import { Contract, Person, PersonSupervisor, Room } from "../models";
 import type { PersonInput } from "../utils";
 import toPersonInput from "../utils";
@@ -242,6 +243,17 @@ router.get("/", async (req: Request, res: Response) => {
       [Op.or]: [
         { firstName: { [Op.iLike]: `%${queryStr}%` } },
         { lastName: { [Op.iLike]: `%${queryStr}%` } },
+        // Search by full name
+        sequelize.where(
+          sequelize.fn(
+            "CONCAT",
+            sequelize.col("person.first_name"),
+            " ",
+            sequelize.col("person.last_name"),
+          ),
+          Op.iLike,
+          `%${queryStr}%`,
+        ),
       ],
     };
 

--- a/backend/src/routes/peopleRouter.ts
+++ b/backend/src/routes/peopleRouter.ts
@@ -1,5 +1,5 @@
 import { Request, Response, Router } from "express";
-import type { FindOptions } from "sequelize";
+import type { FindOptions, InferAttributes } from "sequelize";
 import { Op } from "sequelize";
 import { z } from "zod";
 import { Contract, Person, PersonSupervisor, Room } from "../models";
@@ -215,25 +215,29 @@ router.get("/", async (req: Request, res: Response) => {
       }
     }
 
-    const baseSupervisorsInclude = {
+    const supervisorsInclude = {
       model: Person,
       as: "supervisors",
       through: { attributes: [] },
+      where: {},
+      required: false,
     };
 
-    const baseContractsInclude = {
+    const contractsInclude = {
       model: Contract,
       as: "contracts",
       include: [{ model: Room, as: "room" }],
+      where: {},
+      required: false,
     };
 
-    let findOptions: FindOptions = {
+    const findOptions: FindOptions<InferAttributes<Person>> = {
       include: [
-        baseSupervisorsInclude,
+        supervisorsInclude,
         "department",
         "title",
         "researchGroup",
-        baseContractsInclude,
+        contractsInclude,
       ],
       order: [
         ["lastName", "ASC"],
@@ -243,40 +247,22 @@ router.get("/", async (req: Request, res: Response) => {
 
     switch (type) {
       case "supervisorName":
-        findOptions.include = [
-          {
-            ...baseSupervisorsInclude,
-            where: {
-              [Op.or]: [
-                { firstName: { [Op.iLike]: `%${q}%` } },
-                { lastName: { [Op.iLike]: `%${q}%` } },
-              ],
-            },
-            required: true,
-          },
-          "department",
-          "title",
-          "researchGroup",
-          baseContractsInclude,
-        ];
+        supervisorsInclude.where = {
+          [Op.or]: [
+            { firstName: { [Op.iLike]: `%${q}%` } },
+            { lastName: { [Op.iLike]: `%${q}%` } },
+          ],
+        };
+        supervisorsInclude.required = true;
         break;
 
       case "contractEndDate":
-        findOptions.include = [
-          baseSupervisorsInclude,
-          "department",
-          "title",
-          "researchGroup",
-          {
-            ...baseContractsInclude,
-            where: {
-              endDate: {
-                [Op.lte]: q,
-              },
-            },
-            required: true,
+        contractsInclude.where = {
+          endDate: {
+            [Op.lte]: q,
           },
-        ];
+        };
+        contractsInclude.required = true;
         break;
 
       case "personName":

--- a/backend/src/routes/peopleRouter.ts
+++ b/backend/src/routes/peopleRouter.ts
@@ -209,10 +209,10 @@ router.get("/", async (req: Request, res: Response) => {
   const { q, type } = req.query;
 
   try {
-    if (q && typeof q === "string") {
-      if (q.length > 100) {
-        return res.status(400).json({ error: "Query too long" });
-      }
+    const queryStr = q && typeof q === "string" ? q : undefined;
+
+    if (queryStr && queryStr.length > 100) {
+      return res.status(400).json({ error: "Query too long" });
     }
 
     const supervisorsInclude = {
@@ -245,35 +245,37 @@ router.get("/", async (req: Request, res: Response) => {
       ],
     };
 
-    switch (type) {
-      case "supervisorName":
-        supervisorsInclude.where = {
-          [Op.or]: [
-            { firstName: { [Op.iLike]: `%${q}%` } },
-            { lastName: { [Op.iLike]: `%${q}%` } },
-          ],
-        };
-        supervisorsInclude.required = true;
-        break;
+    if (queryStr) {
+      switch (type) {
+        case "supervisorName":
+          supervisorsInclude.where = {
+            [Op.or]: [
+              { firstName: { [Op.iLike]: `%${queryStr}%` } },
+              { lastName: { [Op.iLike]: `%${queryStr}%` } },
+            ],
+          };
+          supervisorsInclude.required = true;
+          break;
 
-      case "contractEndDate":
-        contractsInclude.where = {
-          endDate: {
-            [Op.lte]: q,
-          },
-        };
-        contractsInclude.required = true;
-        break;
+        case "contractEndDate":
+          contractsInclude.where = {
+            endDate: {
+              [Op.lte]: queryStr,
+            },
+          };
+          contractsInclude.required = true;
+          break;
 
-      case "personName":
-      default:
-        findOptions.where = {
-          [Op.or]: [
-            { firstName: { [Op.iLike]: `%${q}%` } },
-            { lastName: { [Op.iLike]: `%${q}%` } },
-          ],
-        };
-        break;
+        case "personName":
+        default:
+          findOptions.where = {
+            [Op.or]: [
+              { firstName: { [Op.iLike]: `%${queryStr}%` } },
+              { lastName: { [Op.iLike]: `%${queryStr}%` } },
+            ],
+          };
+          break;
+      }
     }
 
     const people = await Person.findAll(findOptions);

--- a/backend/src/routes/peopleRouter.ts
+++ b/backend/src/routes/peopleRouter.ts
@@ -207,58 +207,45 @@ router.put(
 router.get("/", async (req: Request, res: Response) => {
   const { q } = req.query;
 
-  // If query parameter 'q' is provided, search people
-  if (q && typeof q === "string") {
-    if (q.length > 100) {
-      return res.status(400).json({ error: "Query too long" });
+  try {
+    if (q && typeof q === "string") {
+      if (q.length > 100) {
+        return res.status(400).json({ error: "Query too long" });
+      }
     }
 
-    try {
-      const people = await Person.findAll({
-        where: {
+    const where = q
+      ? {
           [Op.or]: [
             { firstName: { [Op.iLike]: `%${q}%` } },
             { lastName: { [Op.iLike]: `%${q}%` } },
           ],
-        },
-        include: [
-          { model: Person, as: "supervisors", through: { attributes: [] } },
-          "department",
-          "title",
-          "researchGroup",
-          {
-            model: Contract,
-            as: "contracts",
-            include: [{ model: Room, as: "room" }],
-          },
-        ],
-      });
+        }
+      : {};
 
-      res.json(people);
-    } catch (error) {
-      console.error("Error searching people:", error);
-      res.status(500).json({ error: "Failed to search people" });
-    }
-  } else {
-    // No query parameter - fetch all people
-    try {
-      const people = await Person.findAll({
-        include: [
-          { model: Person, as: "supervisors", through: { attributes: [] } },
-          "department",
-          "title",
-          "researchGroup",
-        ],
-        order: [
-          ["lastName", "ASC"],
-          ["firstName", "ASC"],
-        ],
-      });
-      res.status(200).json(people);
-    } catch (error) {
-      console.error("Error fetching people:", error);
-      res.status(500).json({ error: "Failed to fetch people" });
-    }
+    const people = await Person.findAll({
+      where,
+      include: [
+        { model: Person, as: "supervisors", through: { attributes: [] } },
+        "department",
+        "title",
+        "researchGroup",
+        {
+          model: Contract,
+          as: "contracts",
+          include: [{ model: Room, as: "room" }],
+        },
+      ],
+      order: [
+        ["lastName", "ASC"],
+        ["firstName", "ASC"],
+      ],
+    });
+
+    res.json(people);
+  } catch (error) {
+    console.error("Error fetching people:", error);
+    res.status(500).json({ error: "Failed to fetch people" });
   }
 });
 

--- a/backend/tests/people.test.ts
+++ b/backend/tests/people.test.ts
@@ -165,6 +165,17 @@ describe("GET /api/people - search", () => {
     expect(response.body[0].lastName).toBe("Virtanen");
   });
 
+  test("people can be searched by full name", async () => {
+    const response = await api
+      .get("/api/people?q=Matti Virtanen")
+      .expect(200)
+      .expect("Content-Type", /application\/json/);
+
+    expect(response.body).toHaveLength(1);
+    expect(response.body[0].firstName).toBe("Matti");
+    expect(response.body[0].lastName).toBe("Virtanen");
+  });
+
   test("search is case-insensitive", async () => {
     const lowercaseResponse = await api.get("/api/people?q=matti").expect(200);
 

--- a/backend/tests/people.test.ts
+++ b/backend/tests/people.test.ts
@@ -329,6 +329,41 @@ describe("GET /api/people - search", () => {
     expect(response.body).toHaveLength(0);
   });
 
+  test("supervisor name search returns subordinates when exactly one supervisor matches", async () => {
+    const response = await api
+      .get("/api/people?q=Matti&type=supervisorName")
+      .expect(200);
+
+    expect(response.body.length).toBeGreaterThan(0);
+    response.body.forEach((person: PersonType) => {
+      expect(person.firstName).not.toBe("Matti");
+      const hasMattisupervisor = person.supervisors?.some(
+        (supervisor) => supervisor.firstName === "Matti",
+      );
+      expect(hasMattisupervisor).toBe(true);
+    });
+  });
+
+  test("supervisor name search returns supervisors when multiple supervisors match", async () => {
+    const response = await api
+      .get("/api/people?q=a&type=supervisorName")
+      .expect(200);
+
+    expect(response.body.length).toBeGreaterThan(0);
+    response.body.forEach((person: PersonType) => {
+      const matchesFirstName = person.firstName.toLowerCase().includes("a");
+      const matchesLastName = person.lastName.toLowerCase().includes("a");
+      expect(matchesFirstName || matchesLastName).toBe(true);
+      expect(person?.subordinates?.length).toBeGreaterThan(0);
+    });
+
+    const firstNames = response.body.map(
+      (person: PersonType) => person.firstName,
+    );
+    expect(firstNames).toContain("Sanna");
+    expect(firstNames).toContain("Matti");
+  });
+
   test("can search by contract end date", async () => {
     const response = await api
       .get("/api/people?q=2025-12-31&type=contractEndDate")

--- a/backend/tests/people.test.ts
+++ b/backend/tests/people.test.ts
@@ -287,7 +287,7 @@ describe("GET /api/people - search", () => {
       .expect(500)
       .expect("Content-Type", /application\/json/);
 
-    expect(response.body.error).toBe("Failed to search people");
+    expect(response.body.error).toBe("Failed to fetch people");
     findAllSpy.mockRestore();
   });
 });

--- a/backend/tests/people.test.ts
+++ b/backend/tests/people.test.ts
@@ -328,6 +328,34 @@ describe("GET /api/people - search", () => {
 
     expect(response.body).toHaveLength(0);
   });
+
+  test("can search by contract end date", async () => {
+    const response = await api
+      .get("/api/people?q=2025-12-31&type=contractEndDate")
+      .expect(200)
+      .expect("Content-Type", /application\/json/);
+
+    expect(response.body.length).toBeGreaterThan(0);
+    response.body.forEach((person: PersonType) => {
+      expect(person.contracts).toBeDefined();
+      const hasMatchingContract = person.contracts?.some((contract) => {
+        if (!contract.endDate) return false;
+        const endDateStr = new Date(contract.endDate)
+          .toISOString()
+          .split("T")[0];
+        return endDateStr <= "2025-12-31";
+      });
+      expect(hasMatchingContract).toBe(true);
+    });
+  });
+
+  test("contract end date search returns empty array when no matches found", async () => {
+    const response = await api
+      .get("/api/people?q=2020-01-01&type=contractEndDate")
+      .expect(200);
+
+    expect(response.body).toHaveLength(0);
+  });
 });
 
 test("a person can be updated", async () => {

--- a/backend/tests/people.test.ts
+++ b/backend/tests/people.test.ts
@@ -290,6 +290,44 @@ describe("GET /api/people - search", () => {
     expect(response.body.error).toBe("Failed to fetch people");
     findAllSpy.mockRestore();
   });
+
+  test("can search by supervisor name", async () => {
+    const response = await api
+      .get("/api/people?q=Matti&type=supervisorName")
+      .expect(200)
+      .expect("Content-Type", /application\/json/);
+
+    expect(response.body.length).toBeGreaterThan(0);
+    response.body.forEach((person: PersonType) => {
+      expect(person.supervisors).toBeDefined();
+      const hasMattisupervisor = person.supervisors?.some((supervisor) =>
+        supervisor.firstName.toLowerCase().includes("matti"),
+      );
+      expect(hasMattisupervisor).toBe(true);
+    });
+  });
+
+  test("supervisor name search is case-insensitive", async () => {
+    const lowercaseResponse = await api
+      .get("/api/people?q=matti&type=supervisorName")
+      .expect(200);
+
+    const uppercaseResponse = await api
+      .get("/api/people?q=MATTI&type=supervisorName")
+      .expect(200);
+
+    expect(lowercaseResponse.body.length).toBeGreaterThan(0);
+    expect(uppercaseResponse.body.length).toBeGreaterThan(0);
+    expect(lowercaseResponse.body.length).toBe(uppercaseResponse.body.length);
+  });
+
+  test("supervisor name search returns empty array when no matches found", async () => {
+    const response = await api
+      .get("/api/people?q=NonexistentSupervisor&type=supervisorName")
+      .expect(200);
+
+    expect(response.body).toHaveLength(0);
+  });
 });
 
 test("a person can be updated", async () => {


### PR DESCRIPTION
### Description

Extended the GET /api/people endpoint to support multiple search types via optional `type` query parameter. New search types allow filtering by supervisor name and contract end date in addition to the default person name search.
Enhanced name search to support full name queries.

**Query Parameters:**
- `q`: Search term
- `type`: `personName` (default), `supervisorName`, or `contractEndDate`

**Search Types:**
- `supervisorName`: Returns people whose supervisors match the search term (case-insensitive)
  - Returns subordinates when exactly one supervisor matches the search term
  - Returns matching supervisors when multiple supervisors match (with their subordinates included)
- `contractEndDate`: Returns people with contracts ending on or before the specified date (YYYY-MM-DD)

### Architecture

GET /api/people endpoint refactored to use a single consolidated query with:
- Conditional `where` clauses based on search type
- Conditional INNER/LEFT JOINs using `required: true/false` on includes
- Reusable `supervisorsInclude` and `contractsInclude` objects to avoid duplication
- Proper Sequelize `FindOptions<InferAttributes<Person>>` typing

### Motive

Enable users to search for people by different criteria.

### Testing

Added integration tests covering:
- Person name search by full name
- Supervisor name search returning subordinates when exactly one supervisor matches
- Supervisor name search returning supervisors when multiple supervisors match
- Case-insensitive supervisor name search validation
- Empty result handling for supervisor name search
- Contract end date search with matching results
- Empty result handling for contract end date search

### Documentation

No changes.