### PR TITLE
fix: prevent duplicate person creation when adding existing persons to rooms

### DIFF
--- a/frontend/src/components/RoomPeople.tsx
+++ b/frontend/src/components/RoomPeople.tsx
@@ -3,7 +3,7 @@ import { AnimatePresence, motion } from "motion/react";
 import { useEffect, useReducer } from "react";
 import Skeleton from "react-loading-skeleton";
 import { useRoomSelection } from "../hooks/useRoomSelection";
-import { removeContract } from "../services/contractsService";
+import { createContract, removeContract } from "../services/contractsService";
 import { addPerson, editPerson } from "../services/peopleService";
 import type { Person, RoomContract } from "../types";
 import { EXPAND_COLLAPSE_TRANSITION } from "../utils/motionTransitions";
@@ -111,6 +111,13 @@ function RoomPeople() {
     try {
       if (state.activePerson) {
         await editPerson(state.activePerson.id, values, activeRoom.id);
+      } else if (values.personId) {
+        await createContract(
+          Number(values.personId),
+          activeRoom.id,
+          values.startDate || null,
+          values.endDate || null,
+        );
       } else {
         await addPerson(values, activeRoom.id);
       }

--- a/frontend/tests/components/sidePanel.test.tsx
+++ b/frontend/tests/components/sidePanel.test.tsx
@@ -6,7 +6,10 @@ import { describe, expect, it, vi } from "vitest";
 import { RoomSelectionProvider } from "../../src/components/RoomSelectionProvider";
 import SidePanel from "../../src/components/SidePanel";
 import { useRoomSelection } from "../../src/hooks/useRoomSelection";
-import { removeContract } from "../../src/services/contractsService";
+import {
+  createContract,
+  removeContract,
+} from "../../src/services/contractsService";
 import {
   addPerson,
   editPerson,
@@ -23,6 +26,7 @@ vi.mock("../../src/services/peopleService", () => ({
 }));
 
 vi.mock("../../src/services/contractsService", () => ({
+  createContract: vi.fn(),
   removeContract: vi.fn(),
 }));
 
@@ -221,6 +225,37 @@ describe("RoomPeople", () => {
       }),
       testRooms[0].id,
     );
+  });
+
+  it("creates contract when selecting existing person without creating new person", async () => {
+    const user = userEvent.setup();
+
+    customRender(<TestDisplay />);
+
+    await user.click(screen.getByTestId("open-empty-room"));
+    await user.click(
+      screen.getByRole("button", {
+        name: "Sijoita henkilö huoneeseen",
+      }),
+    );
+
+    const searchInput = screen.getByLabelText("Hae henkilö:");
+    await user.type(searchInput, "Matti");
+    await screen.findByText("Matti Virtanen");
+    await user.click(screen.getByText("Matti Virtanen"));
+
+    await user.click(screen.getByRole("button", { name: "Lisää" }));
+
+    const confirm = await screen.findByRole("alertdialog");
+    await user.click(within(confirm).getByRole("button", { name: "Tallenna" }));
+
+    expect(createContract).toHaveBeenCalledWith(
+      testPerson.id,
+      testRooms[1].id,
+      null,
+      null,
+    );
+    expect(addPerson).not.toHaveBeenCalled();
   });
 
   it.fails("does not close the modal when adding fails", async () => {


### PR DESCRIPTION
### Description

Fixes a bug where selecting an existing person from search and adding them to a room would create a duplicate person instead of linking the existing person to the room. The fix restores previously removed logic that checks if an existing person is selected (via `values.personId`) and calls `createContract` instead of `addPerson`.

This logic was originally introduced in [#417](https://github.com/hytis-ohtu/hytis/pull/417/changes/60d8d6ee610808934a7936125400eb2724405ff5) but was accidentally removed.

### Architecture

No changes.

### Motive

Previously, when users selected an existing person from the search dropdown to add to a room, the application would call `addPerson`, which created a duplicate person record. The correct behavior is to call `createContract` to link the existing person to the room. This bug was caused by accidentally removed logic that was checking for existing person selection.

### Testing

Added a component test in `sidePanel.test.tsx` that verifies:
- When an existing person is selected from search and added to a room, `createContract` is called with the correct parameters
- `addPerson` is NOT called, preventing duplicate person creation

### Documentation

No changes.