### PR TITLE
feat: update modal styles

### DIFF
--- a/e2e-tests/add-person.spec.ts
+++ b/e2e-tests/add-person.spec.ts
@@ -28,11 +28,11 @@ async function searchAndSelectExistingPerson(page: Page, name: string) {
 
 async function saveAndConfirmPerson(page: Page) {
   await page
-    .locator(".personmodal-actions")
-    .getByRole("button", { name: "Lisää", exact: true })
+    .getByRole("dialog", { name: "Lisää henkilö" })
+    .getByRole("button", { name: "Lisää" })
     .click();
   await page
-    .locator(".confirmation-modal")
+    .getByRole("alertdialog", { name: "Tallenna muutokset?" })
     .getByRole("button", { name: "Tallenna" })
     .click();
 }
@@ -46,7 +46,7 @@ test("person modal can be opened", async ({ page }) => {
 
 test("confirming close dismisses modal", async ({ page }) => {
   await openAddPersonModal(page);
-  await page.locator(".personmodal-close-button").click();
+  await page.locator(".person-modal-close-button").click();
   await page.getByText("Kyllä").click();
   await expect(
     page.getByRole("heading", { name: "Lisää henkilö" }),
@@ -55,7 +55,7 @@ test("confirming close dismisses modal", async ({ page }) => {
 
 test("cancelling close keeps modal open", async ({ page }) => {
   await openAddPersonModal(page);
-  await page.locator(".personmodal-close-button").click();
+  await page.locator(".person-modal-close-button").click();
   await page.getByText("Peruuta").click();
   await expect(
     page.getByRole("heading", { name: "Lisää henkilö" }),
@@ -83,7 +83,7 @@ test("saving opens confirmation dialog", async ({ page }) => {
   await openAddPersonModal(page);
   await fillRequiredFields(page);
   await page
-    .locator(".personmodal-actions")
+    .locator(".person-modal-actions")
     .getByRole("button", { name: "Lisää", exact: true })
     .click();
   await expect(page.getByText("Tallenna muutokset?")).toBeVisible();
@@ -91,15 +91,19 @@ test("saving opens confirmation dialog", async ({ page }) => {
 
 test("clicking outside modal opens confirmation dialog", async ({ page }) => {
   await openAddPersonModal(page);
-  await page.locator(".personmodal-overlay").dispatchEvent("click");
-  await expect(page.getByText("Sulje ilman tallennusta?")).toBeVisible();
+  await page
+    .getByRole("dialog", { name: "Lisää henkilö" })
+    .dispatchEvent("click");
+  await expect(
+    page.getByRole("alertdialog", { name: "Sulje ilman tallennusta?" }),
+  ).toBeVisible();
 });
 
 test("cancelling save confirmation keeps modal open", async ({ page }) => {
   await openAddPersonModal(page);
   await fillRequiredFields(page);
   await page
-    .locator(".personmodal-actions")
+    .locator(".person-modal-actions")
     .getByRole("button", { name: "Lisää", exact: true })
     .click();
   await page.getByText("Peruuta").click();
@@ -113,7 +117,7 @@ test("confirming save closes modal", async ({ page }) => {
   await fillRequiredFields(page);
   await saveAndConfirmPerson(page);
   await expect(
-    page.getByRole("heading", { name: "Lisää henkilö" }),
+    page.getByRole("dialog", { name: "Lisää henkilö" }),
   ).not.toBeVisible();
 });
 

--- a/e2e-tests/add-person.spec.ts
+++ b/e2e-tests/add-person.spec.ts
@@ -11,19 +11,18 @@ async function openAddPersonModal(page: Page) {
 }
 
 async function fillRequiredFields(page: Page) {
-  await page.getByLabel("Etunimi:").fill("Matti");
-  await page.getByLabel("Sukunimi:").fill("Meikäläinen");
-  await page.getByLabel("Osasto:").selectOption({ index: 1 });
-  await page.getByLabel("Työnimike:").selectOption({ index: 1 });
-  await page.getByLabel("Esihenkilö(t):").fill("Joku");
-  await page.getByLabel("Sopimuksen alku:").fill("2025-01-01");
-  await page.getByLabel("Sopimuksen loppu:").fill("2026-01-01");
+  await page.getByLabel("Etunimi").fill("Matti");
+  await page.getByLabel("Sukunimi").fill("Meikäläinen");
+  await page.getByLabel("Osasto").selectOption({ index: 1 });
+  await page.getByLabel("Työnimike").selectOption({ index: 1 });
+  await page.getByLabel("Esihenkilö(t)").fill("Joku");
+  await page.getByLabel("Sopimuksen alku").fill("2025-01-01");
+  await page.getByLabel("Sopimuksen loppu").fill("2026-01-01");
 }
 
 async function searchAndSelectExistingPerson(page: Page, name: string) {
-  await page.getByLabel("Hae henkilö:").fill(name);
-  await page.waitForSelector(".personform-person-option");
-  await page.locator(".personform-person-option").first().click();
+  await page.getByLabel(/^nimi$/i).fill(name);
+  await page.locator(".person-selector-option").first().click();
 }
 
 async function saveAndConfirmPerson(page: Page) {
@@ -46,7 +45,7 @@ test("person modal can be opened", async ({ page }) => {
 
 test("confirming close dismisses modal", async ({ page }) => {
   await openAddPersonModal(page);
-  await page.locator(".person-modal-close-button").click();
+  await page.getByRole("button", { name: "Sulje henkilön lisäys" }).click();
   await page.getByText("Kyllä").click();
   await expect(
     page.getByRole("heading", { name: "Lisää henkilö" }),
@@ -55,8 +54,11 @@ test("confirming close dismisses modal", async ({ page }) => {
 
 test("cancelling close keeps modal open", async ({ page }) => {
   await openAddPersonModal(page);
-  await page.locator(".person-modal-close-button").click();
-  await page.getByText("Peruuta").click();
+  await page.getByRole("button", { name: "Sulje henkilön lisäys" }).click();
+  await page
+    .getByRole("alertdialog")
+    .getByRole("button", { name: "Peruuta" })
+    .click();
   await expect(
     page.getByRole("heading", { name: "Lisää henkilö" }),
   ).toBeVisible();
@@ -74,9 +76,7 @@ test("save button is enabled when required fields are filled", async ({
 }) => {
   await openAddPersonModal(page);
   await fillRequiredFields(page);
-  await expect(
-    page.getByRole("button", { name: "Lisää", exact: true }),
-  ).toBeEnabled();
+  await expect(page.getByRole("button", { name: "Lisää" })).toBeEnabled();
 });
 
 test("saving opens confirmation dialog", async ({ page }) => {
@@ -106,7 +106,10 @@ test("cancelling save confirmation keeps modal open", async ({ page }) => {
     .locator(".person-modal-actions")
     .getByRole("button", { name: "Lisää", exact: true })
     .click();
-  await page.getByText("Peruuta").click();
+  await page
+    .getByRole("alertdialog")
+    .getByRole("button", { name: "Peruuta" })
+    .click();
   await expect(
     page.getByRole("heading", { name: "Lisää henkilö" }),
   ).toBeVisible();
@@ -125,10 +128,9 @@ test("searching for existing person returns matching results", async ({
   page,
 }) => {
   await openAddPersonModal(page);
-  await page.getByLabel("Hae henkilö:").fill("Ahmed Ali");
-  await page.waitForSelector(".personform-person-option");
-  await expect(page.locator(".personform-person-option")).toHaveCount(1);
-  await expect(page.locator(".personform-person-option")).toContainText(
+  await page.getByRole("textbox", { name: /^nimi$/i }).fill("Ahmed Ali");
+  await expect(page.locator(".person-selector-option")).toHaveCount(1);
+  await expect(page.locator(".person-selector-option")).toContainText(
     "Ahmed Ali",
   );
 });
@@ -138,12 +140,12 @@ test("selecting existing person populates person form fields", async ({
 }) => {
   await openAddPersonModal(page);
   await searchAndSelectExistingPerson(page, "Ahmed Ali");
-  await expect(page.getByLabel("Etunimi:")).toHaveValue("Ahmed");
-  await expect(page.getByLabel("Sukunimi:")).toHaveValue("Ali");
-  await expect(page.getByLabel("Osasto:")).toContainText("H523 CS");
-  await expect(page.getByLabel("Työnimike:")).toContainText("professori");
+  await expect(page.getByLabel("Etunimi")).toHaveValue("Ahmed");
+  await expect(page.getByLabel("Sukunimi")).toHaveValue("Ali");
+  await expect(page.getByLabel("Osasto")).toContainText("H523 CS");
+  await expect(page.getByLabel("Työnimike")).toContainText("professori");
 
-  const supervisorTag = page.locator(".personform-supervisor-tag");
+  const supervisorTag = page.locator(".person-form-supervisor");
 
   await expect(supervisorTag).toHaveCount(1);
   await expect(supervisorTag).toContainText("Päivi Koskinen");
@@ -154,16 +156,16 @@ test("existing person form fields are read-only except contract dates", async ({
 }) => {
   await openAddPersonModal(page);
   await searchAndSelectExistingPerson(page, "Ahmed Ali");
-  await expect(page.getByLabel("Etunimi:")).toBeDisabled();
-  await expect(page.getByLabel("Sukunimi:")).toBeDisabled();
-  await expect(page.getByLabel("Osasto:")).toBeDisabled();
-  await expect(page.getByLabel("Työnimike:")).toBeDisabled();
+  await expect(page.getByLabel("Etunimi")).toBeDisabled();
+  await expect(page.getByLabel("Sukunimi")).toBeDisabled();
+  await expect(page.getByLabel("Osasto")).toBeDisabled();
+  await expect(page.getByLabel("Työnimike")).toBeDisabled();
 
-  const supervisorTag = page.locator(".personform-supervisor-tag").first();
+  const supervisorTag = page.locator(".person-form-supervisor").first();
   await expect(supervisorTag.locator("button")).toBeDisabled();
 
-  await expect(page.getByLabel("Sopimuksen alku:")).toBeEnabled();
-  await expect(page.getByLabel("Sopimuksen loppu:")).toBeEnabled();
+  await expect(page.getByLabel("Sopimuksen alku")).toBeEnabled();
+  await expect(page.getByLabel("Sopimuksen loppu")).toBeEnabled();
 });
 
 test("selecting existing person enables save button", async ({ page }) => {
@@ -191,8 +193,8 @@ test("saving existing person with contract dates closes the modal and persists p
 }) => {
   await openAddPersonModal(page);
   await searchAndSelectExistingPerson(page, "Ahmed Ali");
-  await page.getByLabel("Sopimuksen alku:").fill("2025-06-01");
-  await page.getByLabel("Sopimuksen loppu:").fill("2026-06-01");
+  await page.getByLabel("Sopimuksen alku").fill("2025-06-01");
+  await page.getByLabel("Sopimuksen loppu").fill("2026-06-01");
   await saveAndConfirmPerson(page);
   await expect(
     page.getByRole("heading", { name: "Lisää henkilö" }),

--- a/e2e-tests/edit-person.spec.ts
+++ b/e2e-tests/edit-person.spec.ts
@@ -38,7 +38,7 @@ test("clicking outside edit person modal triggers cancel confirmation dialog", a
     .click();
 
   // TODO: add semantic clicking target
-  const modalBox = await page.locator(".personmodal-content").boundingBox();
+  const modalBox = await page.locator(".person-modal-content").boundingBox();
   expect(modalBox).not.toBeNull();
   if (!modalBox) {
     throw new Error("Person modal content bounding box not found");
@@ -68,7 +68,7 @@ test("edit person save button is disabled when required fields are empty", async
   const firstNameInput = page.locator('input[name="firstName"]');
   await firstNameInput.clear();
 
-  const saveButton = page.locator(".personmodal-save-button");
+  const saveButton = page.locator(".person-modal-save-button");
   await expect(saveButton).toBeDisabled();
 });
 
@@ -87,8 +87,8 @@ test("cancelling edit person without saving closes the modal", async ({
   await page.getByRole("button", { name: "Sulje henkilön muokkaus" }).click();
   await page.getByRole("button", { name: "Kyllä" }).click();
 
-  await expect(page.locator(".personmodal-content")).not.toBeVisible();
-  await expect(page.locator(".personmodal-overlay")).not.toBeVisible();
+  await expect(page.locator(".person-modal-content")).not.toBeVisible();
+  await expect(page.locator(".person-modal-overlay")).not.toBeVisible();
 });
 
 test("cancelling from confirmation modal keeps the edit person modal open", async ({
@@ -107,7 +107,7 @@ test("cancelling from confirmation modal keeps the edit person modal open", asyn
   await firstNameInput.clear();
   await firstNameInput.fill("Uusi nimi");
 
-  await page.locator(".personmodal-save-button").click();
+  await page.locator(".person-modal-save-button").click();
   await page.getByRole("button", { name: "Peruuta" }).click();
 
   await expect(

--- a/e2e-tests/edit-person.spec.ts
+++ b/e2e-tests/edit-person.spec.ts
@@ -68,7 +68,7 @@ test("edit person save button is disabled when required fields are empty", async
   const firstNameInput = page.locator('input[name="firstName"]');
   await firstNameInput.clear();
 
-  const saveButton = page.locator(".person-modal-save-button");
+  const saveButton = page.getByRole("button", { name: "Tallenna" });
   await expect(saveButton).toBeDisabled();
 });
 
@@ -107,8 +107,11 @@ test("cancelling from confirmation modal keeps the edit person modal open", asyn
   await firstNameInput.clear();
   await firstNameInput.fill("Uusi nimi");
 
-  await page.locator(".person-modal-save-button").click();
-  await page.getByRole("button", { name: "Peruuta" }).click();
+  await page.getByRole("button", { name: "Sulje henkilön muokkaus" }).click();
+  await page
+    .getByRole("alertdialog")
+    .getByRole("button", { name: "Peruuta" })
+    .click();
 
   await expect(
     page.getByRole("heading", { name: "Muokkaa henkilöä" }),

--- a/e2e-tests/edit-room.spec.ts
+++ b/e2e-tests/edit-room.spec.ts
@@ -24,7 +24,7 @@ test("edit room modal can be opened", async ({ page }) => {
 
 test("confirming close dismisses modal", async ({ page }) => {
   await openEditRoomModal(page);
-  await page.locator(".roommodal-close-button").click();
+  await page.locator(".room-modal-close-button").click();
   await page.getByText("Kyllä").click();
   await expect(
     page.getByRole("heading", { name: "Muokkaa huonetta" }),
@@ -33,7 +33,7 @@ test("confirming close dismisses modal", async ({ page }) => {
 
 test("cancelling close keeps modal open", async ({ page }) => {
   await openEditRoomModal(page);
-  await page.locator(".roommodal-close-button").click();
+  await page.locator(".room-modal-close-button").click();
   await page.getByText("Peruuta").click();
   await expect(
     page.getByRole("heading", { name: "Muokkaa huonetta" }),
@@ -49,13 +49,13 @@ test("form fields are pre-populated with existing room values", async ({
 
 test("save button triggers confirmation dialog", async ({ page }) => {
   await openEditRoomModal(page);
-  await page.locator(".roommodal-save-button").click();
+  await page.locator(".room-modal-save-button").click();
   await expect(page.getByText("Tallenna muutokset?")).toBeVisible();
 });
 
 test("cancelling save confirmation keeps modal open", async ({ page }) => {
   await openEditRoomModal(page);
-  await page.locator(".roommodal-save-button").click();
+  await page.locator(".room-modal-save-button").click();
   await page.getByText("Peruuta").click();
   await expect(
     page.getByRole("heading", { name: "Muokkaa huonetta" }),
@@ -65,9 +65,9 @@ test("cancelling save confirmation keeps modal open", async ({ page }) => {
 test("confirming save after editing fields closes modal", async ({ page }) => {
   await openEditRoomModal(page);
   await fillRoomFields(page);
-  await page.locator(".roommodal-save-button").click();
+  await page.locator(".room-modal-save-button").click();
   await page
-    .locator(".confirmation-modal")
+    .getByRole("alertdialog", { name: "Tallenna muutokset?" })
     .getByRole("button", { name: "Tallenna" })
     .click();
   await expect(
@@ -80,9 +80,9 @@ test("saved changes are reflected in room info after modal closes", async ({
 }) => {
   await openEditRoomModal(page);
   await page.getByLabel("Huonetyyppi:").selectOption({ label: "Työhuone" });
-  await page.locator(".roommodal-save-button").click();
+  await page.locator(".room-modal-save-button").click();
   await page
-    .locator(".confirmation-modal")
+    .getByRole("alertdialog", { name: "Tallenna muutokset?" })
     .getByRole("button", { name: "Tallenna" })
     .click();
   await expect(page.getByText("Työhuone")).toBeVisible();

--- a/e2e-tests/edit-room.spec.ts
+++ b/e2e-tests/edit-room.spec.ts
@@ -9,10 +9,10 @@ async function openEditRoomModal(page: Page) {
 }
 
 async function fillRoomFields(page: Page) {
-  await page.getByLabel("Kapasiteetti:").fill("10");
-  await page.getByLabel("Huonetyyppi:").selectOption({ index: 2 });
-  await page.getByLabel("Osasto:").selectOption({ index: 1 });
-  await page.getByLabel("Lisätiedot:").fill("Lisätietoja huoneesta");
+  await page.getByLabel("Kapasiteetti").fill("10");
+  await page.getByLabel("Huonetyyppi").selectOption({ index: 2 });
+  await page.getByLabel("Osasto").selectOption({ index: 1 });
+  await page.getByLabel("Lisätiedot").fill("Lisätietoja huoneesta");
 }
 
 test("edit room modal can be opened", async ({ page }) => {
@@ -24,7 +24,7 @@ test("edit room modal can be opened", async ({ page }) => {
 
 test("confirming close dismisses modal", async ({ page }) => {
   await openEditRoomModal(page);
-  await page.locator(".room-modal-close-button").click();
+  await page.getByRole("button", { name: "Peruuta" }).click();
   await page.getByText("Kyllä").click();
   await expect(
     page.getByRole("heading", { name: "Muokkaa huonetta" }),
@@ -33,8 +33,11 @@ test("confirming close dismisses modal", async ({ page }) => {
 
 test("cancelling close keeps modal open", async ({ page }) => {
   await openEditRoomModal(page);
-  await page.locator(".room-modal-close-button").click();
-  await page.getByText("Peruuta").click();
+  await page.getByRole("button", { name: "Peruuta" }).click();
+  await page
+    .getByRole("alertdialog")
+    .getByRole("button", { name: "Peruuta" })
+    .click();
   await expect(
     page.getByRole("heading", { name: "Muokkaa huonetta" }),
   ).toBeVisible();
@@ -44,19 +47,22 @@ test("form fields are pre-populated with existing room values", async ({
   page,
 }) => {
   await openEditRoomModal(page);
-  await expect(page.getByLabel("Kapasiteetti:")).not.toHaveValue("");
+  await expect(page.getByLabel("Kapasiteetti")).not.toHaveValue("");
 });
 
 test("save button triggers confirmation dialog", async ({ page }) => {
   await openEditRoomModal(page);
-  await page.locator(".room-modal-save-button").click();
+  await page.getByRole("button", { name: "Tallenna" }).click();
   await expect(page.getByText("Tallenna muutokset?")).toBeVisible();
 });
 
 test("cancelling save confirmation keeps modal open", async ({ page }) => {
   await openEditRoomModal(page);
-  await page.locator(".room-modal-save-button").click();
-  await page.getByText("Peruuta").click();
+  await page.getByRole("button", { name: "Tallenna" }).click();
+  await page
+    .getByRole("alertdialog")
+    .getByRole("button", { name: "Peruuta" })
+    .click();
   await expect(
     page.getByRole("heading", { name: "Muokkaa huonetta" }),
   ).toBeVisible();
@@ -65,7 +71,7 @@ test("cancelling save confirmation keeps modal open", async ({ page }) => {
 test("confirming save after editing fields closes modal", async ({ page }) => {
   await openEditRoomModal(page);
   await fillRoomFields(page);
-  await page.locator(".room-modal-save-button").click();
+  await page.getByRole("button", { name: "Tallenna" }).click();
   await page
     .getByRole("alertdialog", { name: "Tallenna muutokset?" })
     .getByRole("button", { name: "Tallenna" })
@@ -79,8 +85,8 @@ test("saved changes are reflected in room info after modal closes", async ({
   page,
 }) => {
   await openEditRoomModal(page);
-  await page.getByLabel("Huonetyyppi:").selectOption({ label: "Työhuone" });
-  await page.locator(".room-modal-save-button").click();
+  await page.getByLabel("Huonetyyppi").selectOption({ label: "Työhuone" });
+  await page.getByRole("button", { name: "Tallenna" }).click();
   await page
     .getByRole("alertdialog", { name: "Tallenna muutokset?" })
     .getByRole("button", { name: "Tallenna" })

--- a/frontend/src/components/ConfirmationDialog/ConfirmationDialog.css
+++ b/frontend/src/components/ConfirmationDialog/ConfirmationDialog.css
@@ -1,15 +1,15 @@
 .confirmation-dialog {
   min-width: 250px;
-  gap: 0.5rem;
   background: var(--color-background);
   border: var(--border-md);
   padding: 0.5rem;
   box-shadow: var(--box-shadow);
-}
 
-.confirmation-dialog[open] {
-  display: grid;
-  justify-items: center;
+  &[open] {
+    display: grid;
+    gap: 0.5rem;
+    justify-items: center;
+  }
 }
 
 .confirmation-dialog > h2 {
@@ -20,10 +20,10 @@
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 0.5rem;
-}
 
-.confirmation-button:disabled {
-  background-color: var(--color-muted);
-  cursor: not-allowed;
-  pointer-events: none;
+  & > .button:disabled {
+    background-color: var(--color-muted);
+    cursor: not-allowed;
+    pointer-events: none;
+  }
 }

--- a/frontend/src/components/ConfirmationDialog/ConfirmationDialog.css
+++ b/frontend/src/components/ConfirmationDialog/ConfirmationDialog.css
@@ -1,61 +1,29 @@
-.confirmation-overlay {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.4);
-  z-index: 1;
-  display: grid;
-  place-items: center;
-}
-
-.confirmation-modal {
-  position: relative;
+.confirmation-dialog {
+  min-width: 250px;
+  gap: 0.5rem;
   background: var(--color-background);
-  border: 1px solid var(--color-secondary);
-  border-radius: var(--border-radius-md);
-  padding: var(--gap);
-  min-width: 280px;
+  border: var(--border-md);
+  padding: 0.5rem;
   box-shadow: var(--box-shadow);
 }
 
-.confirmation-title {
-  color: var(--color-text-black);
-  font-size: 24px;
-  margin-bottom: var(--gap);
-  margin-right: 20px;
-  text-align: center;
+.confirmation-dialog[open] {
+  display: grid;
+  justify-items: center;
+}
+
+.confirmation-dialog > h2 {
+  font-weight: 500;
 }
 
 .confirmation-buttons {
-  display: flex;
-  flex-direction: row;
-  gap: 8px;
-  margin-top: var(--gap);
-}
-
-.confirmation-button {
-  align-items: center;
-  display: flex;
-  gap: 8px;
-  width: 100%;
-  padding: 8px 12px;
-  border: none;
-  background: var(--color-primary);
-  color: var(--color-text-white);
-  text-align: center;
-  cursor: pointer;
-  border-radius: var(--border-radius-md);
-  transition:
-    background var(--transition-fast),
-    color var(--transition-fast);
-}
-
-.confirmation-button:hover {
-  background: var(--color-muted);
-  color: var(--color-primary);
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.5rem;
 }
 
 .confirmation-button:disabled {
-  opacity: 0.4;
+  background-color: var(--color-muted);
   cursor: not-allowed;
   pointer-events: none;
 }

--- a/frontend/src/components/ConfirmationDialog/ConfirmationDialog.tsx
+++ b/frontend/src/components/ConfirmationDialog/ConfirmationDialog.tsx
@@ -1,41 +1,44 @@
-import { useEffect, useId, useRef } from "react";
+import { type KeyboardEvent, useEffect, useId, useRef } from "react";
 import "./ConfirmationDialog.css";
 
 interface ConfirmDialogProps {
-  isOpen: boolean;
   title?: string;
   confirmText?: string;
   cancelText?: string;
   onConfirm: () => void;
-  onCancel: () => void;
+  onClose: () => void;
 }
 
 export default function ConfirmDialog({
-  isOpen,
   title = "Oletko varma?",
   confirmText = "Kyllä",
   cancelText = "Ei",
   onConfirm,
-  onCancel,
+  onClose,
 }: ConfirmDialogProps) {
   const dialogRef = useRef<HTMLDialogElement>(null);
   const titleId = useId();
 
-  // Toggle dialog
   useEffect(() => {
-    const dialogElement = dialogRef.current;
-    if (!dialogElement) {
-      return;
-    }
+    dialogRef.current?.showModal();
+  }, []);
 
-    if (isOpen && !dialogElement.open) {
-      dialogElement.showModal();
-    }
+  const handleEscape = (e: KeyboardEvent<HTMLDialogElement>) => {
+    if (e.key !== "Escape") return;
+    e.preventDefault();
+    e.stopPropagation();
+    handleCancel();
+  };
 
-    if (!isOpen && dialogElement.open) {
-      dialogElement.close();
-    }
-  }, [isOpen]);
+  const handleCancel = () => {
+    dialogRef.current?.close();
+    onClose();
+  };
+
+  const handleConfirm = () => {
+    dialogRef.current?.close();
+    onConfirm();
+  };
 
   return (
     <dialog
@@ -43,16 +46,16 @@ export default function ConfirmDialog({
       className="confirmation-dialog"
       role="alertdialog"
       aria-labelledby={titleId}
-      onClose={onCancel}
+      onKeyDown={handleEscape}
     >
       <h2 id={titleId} className="confirmation-title">
         {title}
       </h2>
       <div className="confirmation-buttons">
-        <button className="button" onClick={onConfirm}>
+        <button className="button" onClick={handleConfirm}>
           {confirmText}
         </button>
-        <button className="button" onClick={onCancel}>
+        <button className="button" onClick={handleCancel}>
           {cancelText}
         </button>
       </div>

--- a/frontend/src/components/ConfirmationDialog/ConfirmationDialog.tsx
+++ b/frontend/src/components/ConfirmationDialog/ConfirmationDialog.tsx
@@ -49,10 +49,10 @@ export default function ConfirmDialog({
         {title}
       </h2>
       <div className="confirmation-buttons">
-        <button className="button confirmation-button" onClick={onConfirm}>
+        <button className="button" onClick={onConfirm}>
           {confirmText}
         </button>
-        <button className="button confirmation-button" onClick={onCancel}>
+        <button className="button" onClick={onCancel}>
           {cancelText}
         </button>
       </div>

--- a/frontend/src/components/ConfirmationDialog/ConfirmationDialog.tsx
+++ b/frontend/src/components/ConfirmationDialog/ConfirmationDialog.tsx
@@ -1,40 +1,61 @@
+import { useEffect, useId, useRef } from "react";
 import "./ConfirmationDialog.css";
 
 interface ConfirmDialogProps {
-  open: boolean;
+  isOpen: boolean;
   title?: string;
   confirmText?: string;
   cancelText?: string;
   onConfirm: () => void;
   onCancel: () => void;
 }
+
 export default function ConfirmDialog({
-  open,
+  isOpen,
   title = "Oletko varma?",
   confirmText = "Kyllä",
   cancelText = "Ei",
   onConfirm,
   onCancel,
 }: ConfirmDialogProps) {
-  if (!open) return null;
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const titleId = useId();
+
+  // Toggle dialog
+  useEffect(() => {
+    const dialogElement = dialogRef.current;
+    if (!dialogElement) {
+      return;
+    }
+
+    if (isOpen && !dialogElement.open) {
+      dialogElement.showModal();
+    }
+
+    if (!isOpen && dialogElement.open) {
+      dialogElement.close();
+    }
+  }, [isOpen]);
+
   return (
-    <div className="confirmation-overlay" onClick={onCancel}>
-      <div
-        className="confirmation-modal"
-        role="alertdialog"
-        aria-modal="true"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <h2 className="confirmation-title">{title}</h2>
-        <div className="confirmation-buttons">
-          <button className="confirmation-button" onClick={onConfirm}>
-            {confirmText}
-          </button>
-          <button className="confirmation-button" onClick={onCancel}>
-            {cancelText}
-          </button>
-        </div>
+    <dialog
+      ref={dialogRef}
+      className="confirmation-dialog"
+      role="alertdialog"
+      aria-labelledby={titleId}
+      onClose={onCancel}
+    >
+      <h2 id={titleId} className="confirmation-title">
+        {title}
+      </h2>
+      <div className="confirmation-buttons">
+        <button className="button confirmation-button" onClick={onConfirm}>
+          {confirmText}
+        </button>
+        <button className="button confirmation-button" onClick={onCancel}>
+          {cancelText}
+        </button>
       </div>
-    </div>
+    </dialog>
   );
 }

--- a/frontend/src/components/MapView/ColorToggle/ColorToggle.css
+++ b/frontend/src/components/MapView/ColorToggle/ColorToggle.css
@@ -1,5 +1,5 @@
 .color-toggle {
-  padding: 0.5rem 0.75rem;
+  padding: 0.325rem 0.75rem;
   border: var(--border-md);
   border-radius: var(--border-radius-md);
   background-color: var(--color-background);

--- a/frontend/src/components/MapView/ColorToggle/ColorToggle.tsx
+++ b/frontend/src/components/MapView/ColorToggle/ColorToggle.tsx
@@ -11,7 +11,7 @@ function ColorToggle({
 }: ColorToggleProps) {
   return (
     <button
-      className="button color-toggle"
+      className="color-toggle"
       onClick={() => setUseAvailability(!useAvailability)}
     >
       {useAvailability ? "Vastuualueet" : "Varaustila"}

--- a/frontend/src/components/MapView/ZoomButtons/ZoomButtons.css
+++ b/frontend/src/components/MapView/ZoomButtons/ZoomButtons.css
@@ -6,10 +6,10 @@
   box-shadow: var(--box-shadow);
 }
 
-.zoom-buttons button {
+.zoom-buttons .button.icon {
   padding: 0.25rem 0.5rem;
 }
 
-.zoom-buttons button:first-of-type {
+.zoom-buttons .button.icon:first-of-type {
   border-right: 2px solid var(--color-text-black);
 }

--- a/frontend/src/components/MapView/ZoomButtons/ZoomButtons.tsx
+++ b/frontend/src/components/MapView/ZoomButtons/ZoomButtons.tsx
@@ -9,14 +9,14 @@ function ZoomButtons({ onZoom }: ZoomButtonsProps) {
   return (
     <div className="zoom-buttons">
       <button
-        className="button-icon"
+        className="button icon"
         aria-label="Suurenna"
         onClick={() => onZoom(true)}
       >
         <Plus size={20} />
       </button>
       <button
-        className="button-icon"
+        className="button icon"
         aria-label="Loitonna"
         onClick={() => onZoom(false)}
       >

--- a/frontend/src/components/PersonModal/PersonForm/PersonForm.css
+++ b/frontend/src/components/PersonModal/PersonForm/PersonForm.css
@@ -1,86 +1,72 @@
-.personform-container {
-  padding: 1rem;
-  display: flex;
-  justify-content: center;
+.person-form {
+  display: grid;
+  grid-template-columns: 1fr min-content;
+  gap: 0.75rem 2rem;
 }
 
-.personform-form {
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-  width: 100%;
-  max-width: 400px;
-}
-
-.personform-field {
-  display: flex;
+.person-form-entry {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: subgrid;
   align-items: center;
 }
 
-.personform-field--top {
-  align-items: flex-start;
+.person-form-entry:has(.person-selector) {
+  row-gap: 0.5rem;
 }
 
-.personform-label {
-  flex: 0 0 140px;
-  text-align: center;
-  margin-right: 0.5rem;
-  font-weight: 600;
-  color: var(--color-text-black);
-}
-
-.personform-field--top .personform-label {
-  padding-top: 0.5rem;
-}
-
-.personform-input {
-  flex: 1;
-  min-width: 0;
-  padding: 0.5rem;
-  background-color: var(--color-background);
-  border: var(--border-sm);
-  border-radius: var(--border-radius-md);
-  font-size: 1rem;
-}
-
-select.personform-input {
-  cursor: pointer;
-}
-
-.personform-supervisor {
-  flex: 1;
-  min-width: 0;
-  position: relative;
-}
-
-.personform-supervisor-selected {
+.person-form-supervisors-list {
+  grid-column: 2;
+  grid-row: 2;
   display: flex;
   flex-wrap: wrap;
-  gap: 0.25rem;
-  margin-top: 0.25rem;
+  gap: 0.5rem;
+  min-width: 0;
 }
 
-.personform-supervisor-tag {
+.person-form-separator {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  place-items: center;
+  gap: 1rem;
+
+  .separator-line {
+    width: 100%;
+    height: var(--border-width-md);
+    background: var(--color-text-black);
+  }
+
+  &:not(:first-of-type) {
+    margin-top: 1rem;
+  }
+}
+
+.person-form-input,
+.person-selector-input {
+  padding: 0.5rem;
+  background: var(--color-background);
+  border: var(--border-md);
+}
+
+.person-form-input:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.person-form-supervisor {
   display: flex;
   align-items: center;
   gap: 0.25rem;
   padding: 0.15rem 0.4rem;
-  background: var(--color-secondary);
-  border-radius: 4px;
+  border: var(--border-md);
   font-size: 0.875rem;
+
+  .button.icon {
+    color: var(--color-text-black);
+  }
 }
 
-.personform-supervisor-tag button {
-  background: none;
-  border: none;
-  cursor: pointer;
-  padding: 0;
-  line-height: 1;
-  font-size: 1rem;
-  color: inherit;
-}
-
-.personform-supervisor-tag button:disabled {
-  cursor: not-allowed;
+.person-form-entry.disabled .person-form-supervisor {
   opacity: 0.5;
 }

--- a/frontend/src/components/PersonModal/PersonForm/PersonForm.tsx
+++ b/frontend/src/components/PersonModal/PersonForm/PersonForm.tsx
@@ -7,36 +7,40 @@ import {
   type ReferenceItem,
 } from "@services/referenceDataService";
 import type { Person } from "@types";
+import { X } from "lucide-react";
 import { useEffect, useRef, useState, type ChangeEvent } from "react";
 import "./PersonForm.css";
 
-interface FieldDef {
+interface Field {
   id: string;
   label: string;
   type: "text" | "select" | "date" | "supervisor";
   required: boolean;
 }
 
-const FIELDS: FieldDef[] = [
-  { id: "firstName", label: "Etunimi:", type: "text", required: true },
-  { id: "lastName", label: "Sukunimi:", type: "text", required: true },
-  { id: "department", label: "Osasto:", type: "select", required: false },
-  { id: "jobtitle", label: "Työnimike:", type: "select", required: false },
+const PERSON_FIELDS: Field[] = [
+  { id: "firstName", label: "Etunimi", type: "text", required: true },
+  { id: "lastName", label: "Sukunimi", type: "text", required: true },
+  { id: "department", label: "Osasto", type: "select", required: false },
+  { id: "jobtitle", label: "Työnimike", type: "select", required: false },
   {
     id: "supervisors",
-    label: "Esihenkilö(t):",
+    label: "Esihenkilö(t)",
     type: "supervisor",
     required: false,
   },
-  { id: "startDate", label: "Sopimuksen alku:", type: "date", required: false },
-  { id: "endDate", label: "Sopimuksen loppu:", type: "date", required: false },
   {
     id: "researchgroup",
-    label: "Tutkimusryhmä:",
+    label: "Tutkimusryhmä",
     type: "select",
     required: false,
   },
-  { id: "misc", label: "Muut tiedot:", type: "text", required: false },
+  { id: "misc", label: "Muut tiedot", type: "text", required: false },
+];
+
+const CONTRACT_FIELDS: Field[] = [
+  { id: "startDate", label: "Sopimuksen alku", type: "date", required: false },
+  { id: "endDate", label: "Sopimuksen loppu", type: "date", required: false },
 ];
 
 interface SelectOptions {
@@ -51,7 +55,9 @@ interface PersonFormProps {
 }
 
 const isFormValid = (vals: Record<string, string>): boolean =>
-  FIELDS.filter((f) => f.required).every((f) => Boolean(vals[f.id]?.trim()));
+  PERSON_FIELDS.filter((f) => f.required).every((f) =>
+    Boolean(vals[f.id]?.trim()),
+  );
 
 function PersonForm({ initial = {}, onChange }: PersonFormProps) {
   const [values, setValues] = useState<Record<string, string>>({ ...initial });
@@ -67,6 +73,8 @@ function PersonForm({ initial = {}, onChange }: PersonFormProps) {
   const [supervisorOpen, setSupervisorOpen] = useState(false);
   const existingPersonRef = useRef<HTMLDivElement>(null);
   const supervisorRef = useRef<HTMLDivElement>(null);
+
+  const isEdit = Object.keys(initial).length > 0;
 
   useEffect(() => {
     Promise.all([
@@ -155,113 +163,145 @@ function PersonForm({ initial = {}, onChange }: PersonFormProps) {
   const isExistingPersonSelected = !!values.personId;
 
   return (
-    <div className="personform-container">
-      <div className="personform-form">
-        <div className="personform-field personform-field--top">
-          <label className="personform-label" htmlFor="person-search">
-            Hae henkilö:
-          </label>
-          <PersonSelector
-            inputId="person-search"
-            personRef={existingPersonRef}
-            people={people}
-            personSearch={existingPersonSearch}
-            setPersonSearch={setExistingPersonSearch}
-            personOpen={personOpen}
-            onFocus={() => setPersonOpen(true)}
-            onSelect={(person: Person) => {
-              applyExistingPerson(person);
-              setExistingPersonSearch("");
-              setPersonOpen(false);
-            }}
-            selectedPersonIds={values.personId ? [values.personId] : []}
-          />
-        </div>
-
-        {FIELDS.map(({ id, label, type, required }) => {
-          const isDisabled =
-            isExistingPersonSelected && id !== "startDate" && id !== "endDate";
-          return (
-            <div
-              key={id}
-              className={`personform-field${type === "supervisor" ? " personform-field--top" : ""}${isDisabled ? " personform-field--disabled" : ""}`}
-            >
-              <label className="personform-label" htmlFor={id}>
-                {label}
-              </label>
-              {type === "select" ? (
-                <select
-                  id={id}
-                  name={id}
-                  value={values[id] ?? ""}
-                  onChange={handleChange}
-                  required={required}
-                  disabled={isDisabled}
-                  className="personform-input"
-                >
-                  <option value=""> Valitse </option>
-                  {options[id as keyof SelectOptions].map((item) => (
-                    <option key={item.id} value={String(item.id)}>
-                      {item.name}
-                    </option>
-                  ))}
-                </select>
-              ) : type === "supervisor" ? (
-                <div className="personform-supervisor">
-                  <PersonSelector
-                    inputId={id}
-                    personRef={supervisorRef}
-                    people={people}
-                    personSearch={supervisorSearch}
-                    setPersonSearch={setSupervisorSearch}
-                    personOpen={supervisorOpen}
-                    onFocus={() => setSupervisorOpen(true)}
-                    onSelect={(person: Person) => {
-                      toggleSupervisor(String(person.id));
-                      setSupervisorSearch("");
-                      setSupervisorOpen(false);
-                    }}
-                    selectedPersonIds={selectedSupervisorIds}
-                    disabled={isDisabled}
-                  />
-                  {selectedSupervisorIds.length > 0 && (
-                    <div className="personform-supervisor-selected">
-                      {selectedSupervisorIds.map((sid) => {
-                        const p = people.find((p) => String(p.id) === sid);
-                        return p ? (
-                          <span key={sid} className="personform-supervisor-tag">
-                            {p.firstName} {p.lastName}
-                            <button
-                              type="button"
-                              onClick={() => toggleSupervisor(sid)}
-                              disabled={isDisabled}
-                              aria-label={`Poista ${p.firstName} ${p.lastName}`}
-                            >
-                              ×
-                            </button>
-                          </span>
-                        ) : null;
-                      })}
-                    </div>
-                  )}
-                </div>
-              ) : (
-                <input
-                  id={id}
-                  name={id}
-                  type={type}
-                  value={values[id] ?? ""}
-                  onChange={handleChange}
-                  required={required}
-                  disabled={isDisabled}
-                  className="personform-input"
-                />
-              )}
-            </div>
-          );
-        })}
+    <form className="person-form">
+      <div className="person-form-separator">
+        <span className="separator-line"></span>
+        <p>Hae olemassa oleva henkilö</p>
+        <span className="separator-line"></span>
       </div>
-    </div>
+      <div className="person-form-entry">
+        <label htmlFor="person-search">Nimi</label>
+        <PersonSelector
+          inputId="person-search"
+          personRef={existingPersonRef}
+          people={people}
+          personSearch={existingPersonSearch}
+          setPersonSearch={setExistingPersonSearch}
+          personOpen={personOpen}
+          onFocus={() => setPersonOpen(true)}
+          onSelect={(person: Person) => {
+            applyExistingPerson(person);
+            setExistingPersonSearch("");
+            setPersonOpen(false);
+          }}
+          selectedPersonIds={values.personId ? [values.personId] : []}
+        />
+      </div>
+
+      <div className="person-form-separator">
+        <span className="separator-line"></span>
+        <p>{isEdit ? "Muokkaa henkilön tietoja" : "Luo uusi henkilö"}</p>
+        <span className="separator-line"></span>
+      </div>
+
+      {PERSON_FIELDS.map(({ id, label, type, required }) => {
+        const isDisabled = isExistingPersonSelected;
+        return (
+          <div
+            key={id}
+            className={`person-form-entry${isDisabled ? " disabled" : ""}`}
+          >
+            <label className="person-form-label" htmlFor={id}>
+              {label}
+            </label>
+            {type === "select" ? (
+              <select
+                id={id}
+                name={id}
+                value={values[id] ?? ""}
+                onChange={handleChange}
+                required={required}
+                disabled={isDisabled}
+                className="person-form-input"
+              >
+                <option value=""> Valitse </option>
+                {options[id as keyof SelectOptions].map((item) => (
+                  <option key={item.id} value={String(item.id)}>
+                    {item.name}
+                  </option>
+                ))}
+              </select>
+            ) : type === "supervisor" ? (
+              <>
+                <PersonSelector
+                  inputId={id}
+                  personRef={supervisorRef}
+                  people={people}
+                  personSearch={supervisorSearch}
+                  setPersonSearch={setSupervisorSearch}
+                  personOpen={supervisorOpen}
+                  onFocus={() => setSupervisorOpen(true)}
+                  onSelect={(person: Person) => {
+                    toggleSupervisor(String(person.id));
+                    setSupervisorSearch("");
+                    setSupervisorOpen(false);
+                  }}
+                  selectedPersonIds={selectedSupervisorIds}
+                  disabled={isDisabled}
+                />
+                {selectedSupervisorIds.length > 0 && (
+                  <div className="person-form-supervisors-list">
+                    {selectedSupervisorIds.map((sid) => {
+                      const p = people.find((p) => String(p.id) === sid);
+                      return p ? (
+                        <span key={sid} className="person-form-supervisor">
+                          {p.firstName} {p.lastName}
+                          <button
+                            type="button"
+                            className="button icon"
+                            onClick={() => toggleSupervisor(sid)}
+                            disabled={isDisabled}
+                            aria-label={`Poista ${p.firstName} ${p.lastName}`}
+                          >
+                            <X size={16} />
+                          </button>
+                        </span>
+                      ) : null;
+                    })}
+                  </div>
+                )}
+              </>
+            ) : (
+              <input
+                id={id}
+                name={id}
+                type={type}
+                value={values[id] ?? ""}
+                onChange={handleChange}
+                required={required}
+                disabled={isDisabled}
+                className="person-form-input"
+              />
+            )}
+          </div>
+        );
+      })}
+
+      <div className="person-form-separator">
+        <span className="separator-line"></span>
+        <p>Sopimuksen tiedot</p>
+        <span className="separator-line"></span>
+      </div>
+
+      {CONTRACT_FIELDS.map(({ id, label, type, required }) => {
+        return (
+          <div key={id} className="person-form-entry">
+            <label className="person-form-label" htmlFor={id}>
+              {label}
+            </label>
+            <input
+              id={id}
+              name={id}
+              type={type}
+              value={values[id] ?? ""}
+              onChange={handleChange}
+              required={required}
+              className="person-form-input"
+            />
+          </div>
+        );
+      })}
+    </form>
   );
 }
 

--- a/frontend/src/components/PersonModal/PersonModal.css
+++ b/frontend/src/components/PersonModal/PersonModal.css
@@ -1,23 +1,19 @@
-.personmodal-overlay {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.4);
-  z-index: 1;
-  display: grid;
-  place-items: center;
-}
-
-.personmodal-content {
+.person-modal {
   position: relative;
   background: var(--color-secondary);
-  border: var(--border-sm);
+  border: 1px solid var(--color-secondary);
   border-radius: var(--border-radius-md);
-  padding: var(--gap);
+  padding: 0;
   min-width: 400px;
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
 }
 
-.personmodal-title {
+.person-modal-content {
+  position: relative;
+  padding: var(--gap);
+}
+
+.person-modal-title {
   color: var(--color-text-black);
   font-size: 24px;
   margin-bottom: var(--gap);
@@ -25,12 +21,12 @@
   text-align: center;
 }
 
-.personmodal-actions {
+.person-modal-actions {
   display: flex;
   justify-content: center;
 }
 
-.personmodal-close-button {
+.person-modal-close-button {
   padding: 4px;
   position: absolute;
   top: 4px;
@@ -41,11 +37,11 @@
   cursor: pointer;
 }
 
-.personmodal-close-button:hover {
+.person-modal-close-button:hover {
   color: var(--color-text-white);
 }
 
-.personmodal-save-button {
+.person-modal-save-button {
   align-items: center;
   display: flex;
   gap: 8px;
@@ -64,12 +60,12 @@
     color var(--transition-fast);
 }
 
-.personmodal-save-button:hover {
+.person-modal-save-button:hover {
   background: var(--color-muted);
   color: var(--color-primary);
 }
 
-.personmodal-save-button:disabled {
+.person-modal-save-button:disabled {
   opacity: 0.4;
   cursor: not-allowed;
   pointer-events: none;

--- a/frontend/src/components/PersonModal/PersonModal.css
+++ b/frontend/src/components/PersonModal/PersonModal.css
@@ -1,72 +1,34 @@
 .person-modal {
-  position: relative;
-  background: var(--color-secondary);
-  border: 1px solid var(--color-secondary);
-  border-radius: var(--border-radius-md);
   padding: 0;
-  min-width: 400px;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+  border: var(--border-md);
+  background: var(--color-background);
+  box-shadow: var(--box-shadow);
 }
 
 .person-modal-content {
-  position: relative;
-  padding: var(--gap);
+  display: grid;
+  gap: 1rem;
+  padding: 1rem;
 }
 
-.person-modal-title {
-  color: var(--color-text-black);
-  font-size: 24px;
-  margin-bottom: var(--gap);
-  margin-right: 20px;
-  text-align: center;
+.person-modal-content > header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.person-modal-content > header > h2 {
+  font-weight: 500;
+}
+
+.person-modal-content > header > .button.icon {
+  height: 100%;
+  aspect-ratio: 1;
 }
 
 .person-modal-actions {
-  display: flex;
-  justify-content: center;
-}
-
-.person-modal-close-button {
-  padding: 4px;
-  position: absolute;
-  top: 4px;
-  right: 4px;
-  background: transparent;
-  border: none;
-  color: var(--color-text-black);
-  cursor: pointer;
-}
-
-.person-modal-close-button:hover {
-  color: var(--color-text-white);
-}
-
-.person-modal-save-button {
-  align-items: center;
-  display: flex;
-  gap: 8px;
-  width: auto;
-  min-width: 120px;
-  justify-content: center;
-  padding: 8px 12px;
-  border: none;
-  background: var(--color-primary);
-  color: var(--color-text-white);
-  text-align: center;
-  cursor: pointer;
-  border-radius: var(--border-radius-md);
-  transition:
-    background var(--transition-fast),
-    color var(--transition-fast);
-}
-
-.person-modal-save-button:hover {
-  background: var(--color-muted);
-  color: var(--color-primary);
-}
-
-.person-modal-save-button:disabled {
-  opacity: 0.4;
-  cursor: not-allowed;
-  pointer-events: none;
+  place-self: center;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
 }

--- a/frontend/src/components/PersonModal/PersonModal.tsx
+++ b/frontend/src/components/PersonModal/PersonModal.tsx
@@ -102,28 +102,31 @@ function PersonModal({ onSave, onClose, initial = {} }: PersonModalProps) {
       onClick={handleClick}
     >
       <div className="person-modal-content">
-        <button
-          className="person-modal-close-button"
-          aria-label={
-            isEdit ? "Sulje henkilön muokkaus" : "Sulje henkilön lisäys"
-          }
-          onClick={requestClose}
-        >
-          <X size={16} />
-        </button>
-        <h2 id={titleId} className="person-modal-title">
-          {isEdit ? "Muokkaa henkilöä" : "Lisää henkilö"}
-        </h2>
+        <header>
+          <h2 id={titleId}>{isEdit ? "Muokkaa henkilöä" : "Lisää henkilö"}</h2>
+          <button
+            className="button icon"
+            aria-label={
+              isEdit ? "Sulje henkilön muokkaus" : "Sulje henkilön lisäys"
+            }
+            onClick={requestClose}
+          >
+            <X size={20} />
+          </button>
+        </header>
 
         <PersonForm onChange={handleFormChange} initial={initial} />
 
         <div className="person-modal-actions">
           <button
-            className="person-modal-save-button"
+            className="button"
             onClick={requestSave}
             disabled={!isFormValid}
           >
             {isEdit ? "Tallenna" : "Lisää"}
+          </button>
+          <button className="button" onClick={requestClose}>
+            Peruuta
           </button>
         </div>
       </div>

--- a/frontend/src/components/PersonModal/PersonModal.tsx
+++ b/frontend/src/components/PersonModal/PersonModal.tsx
@@ -85,7 +85,7 @@ function PersonModal({ onClose, onSubmit, initial = {} }: PersonModalProps) {
         </div>
 
         <ConfirmationDialog
-          open={confirmOpen}
+          isOpen={confirmOpen}
           title={
             confirmAction === "save"
               ? "Tallenna muutokset?"

--- a/frontend/src/components/PersonModal/PersonModal.tsx
+++ b/frontend/src/components/PersonModal/PersonModal.tsx
@@ -1,17 +1,25 @@
 import ConfirmationDialog from "@components/ConfirmationDialog/ConfirmationDialog";
 import { X } from "lucide-react";
-import { useCallback, useRef, useState } from "react";
+import {
+  type KeyboardEvent,
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+} from "react";
 import PersonForm from "./PersonForm/PersonForm";
 import "./PersonModal.css";
 
 interface PersonModalProps {
+  onSave: (values: Record<string, string>) => Promise<void>;
   onClose: () => void;
-  onSubmit?: (values: Record<string, string>) => void;
   initial?: Record<string, string>;
 }
 
-function PersonModal({ onClose, onSubmit, initial = {} }: PersonModalProps) {
+function PersonModal({ onSave, onClose, initial = {} }: PersonModalProps) {
   const formDataRef = useRef<Record<string, string>>({ ...initial });
+  const dialogRef = useRef<HTMLDialogElement>(null);
   const [isFormValid, setIsFormValid] = useState(() => {
     const REQUIRED_FIELDS = ["firstName", "lastName"];
     return REQUIRED_FIELDS.every((f) => Boolean(initial[f]?.trim()));
@@ -20,8 +28,20 @@ function PersonModal({ onClose, onSubmit, initial = {} }: PersonModalProps) {
   const [confirmAction, setConfirmAction] = useState<"save" | "close" | null>(
     null,
   );
+  const titleId = useId();
 
   const isEdit = Object.keys(initial).length > 0;
+
+  useEffect(() => {
+    dialogRef.current?.showModal();
+  }, []);
+
+  const handleEscape = (e: KeyboardEvent<HTMLDialogElement>) => {
+    if (e.key !== "Escape") return;
+    e.preventDefault();
+    e.stopPropagation();
+    requestClose();
+  };
 
   const handleFormChange = useCallback(
     (values: Record<string, string>, isValid: boolean) => {
@@ -31,9 +51,19 @@ function PersonModal({ onClose, onSubmit, initial = {} }: PersonModalProps) {
     [],
   );
 
-  const handleSave = () => {
-    onSubmit?.(formDataRef.current);
+  const handleSave = async () => {
+    await onSave(formDataRef.current);
+  };
+
+  const handleClose = () => {
+    dialogRef.current?.close();
     onClose();
+  };
+
+  const handleClick = (e: React.PointerEvent<HTMLDialogElement>) => {
+    if (e.target === e.currentTarget) {
+      requestClose();
+    }
   };
 
   const requestSave = () => {
@@ -45,22 +75,35 @@ function PersonModal({ onClose, onSubmit, initial = {} }: PersonModalProps) {
     setConfirmOpen(true);
   };
 
-  const handleConfirm = () => {
+  const handleConfirmConfirm = async () => {
     setConfirmOpen(false);
-    if (confirmAction === "save") handleSave();
-    if (confirmAction === "close") onClose();
+    if (confirmAction === "save") {
+      try {
+        await handleSave();
+        handleClose();
+      } catch (error) {
+        console.error("Failed to save person:", error);
+      }
+    }
+    if (confirmAction === "close") handleClose();
     setConfirmAction(null);
   };
-  const handleCancel = () => {
+  const handleConfirmClose = () => {
     setConfirmOpen(false);
     setConfirmAction(null);
   };
 
   return (
-    <div className="personmodal-overlay" onClick={requestClose}>
-      <div className="personmodal-content" onClick={(e) => e.stopPropagation()}>
+    <dialog
+      ref={dialogRef}
+      className="person-modal"
+      aria-labelledby={titleId}
+      onKeyDown={handleEscape}
+      onClick={handleClick}
+    >
+      <div className="person-modal-content">
         <button
-          className="personmodal-close-button"
+          className="person-modal-close-button"
           aria-label={
             isEdit ? "Sulje henkilön muokkaus" : "Sulje henkilön lisäys"
           }
@@ -68,24 +111,25 @@ function PersonModal({ onClose, onSubmit, initial = {} }: PersonModalProps) {
         >
           <X size={16} />
         </button>
-        <h2 className="personmodal-title">
+        <h2 id={titleId} className="person-modal-title">
           {isEdit ? "Muokkaa henkilöä" : "Lisää henkilö"}
         </h2>
 
         <PersonForm onChange={handleFormChange} initial={initial} />
 
-        <div className="personmodal-actions">
+        <div className="person-modal-actions">
           <button
-            className="personmodal-save-button"
+            className="person-modal-save-button"
             onClick={requestSave}
             disabled={!isFormValid}
           >
             {isEdit ? "Tallenna" : "Lisää"}
           </button>
         </div>
+      </div>
 
+      {confirmOpen && (
         <ConfirmationDialog
-          isOpen={confirmOpen}
           title={
             confirmAction === "save"
               ? "Tallenna muutokset?"
@@ -93,11 +137,11 @@ function PersonModal({ onClose, onSubmit, initial = {} }: PersonModalProps) {
           }
           confirmText={confirmAction === "save" ? "Tallenna" : "Kyllä"}
           cancelText="Peruuta"
-          onConfirm={handleConfirm}
-          onCancel={handleCancel}
+          onConfirm={() => void handleConfirmConfirm()}
+          onClose={handleConfirmClose}
         />
-      </div>
-    </div>
+      )}
+    </dialog>
   );
 }
 

--- a/frontend/src/components/PersonSearch/PersonSearch.tsx
+++ b/frontend/src/components/PersonSearch/PersonSearch.tsx
@@ -172,7 +172,7 @@ function PersonSearch() {
               }`}
             </p>
             <button
-              className="button-icon person-search-close"
+              className="button icon person-search-close"
               aria-label="Sulje hakutulokset"
               onClick={() => setIsResultsVisible(false)}
             >

--- a/frontend/src/components/PersonSearch/PersonSearch.tsx
+++ b/frontend/src/components/PersonSearch/PersonSearch.tsx
@@ -124,7 +124,6 @@ function PersonSearch() {
 
         <div className="person-search-type">
           <button
-            type="button"
             aria-label="Hakutyyppi"
             aria-haspopup="menu"
             aria-expanded={isTypeMenuOpen}

--- a/frontend/src/components/PersonSelector/PersonSelector.css
+++ b/frontend/src/components/PersonSelector/PersonSelector.css
@@ -1,70 +1,35 @@
-.personform-person {
-  flex: 1;
-  min-width: 0;
+.person-selector {
   position: relative;
+  min-width: 300px;
 }
 
-.personform-person .personform-input {
+.person-selector-input {
   width: 100%;
-  box-sizing: border-box;
-  flex: none;
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
 }
 
-.personform-person-selected {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.25rem;
-  margin-top: 0.25rem;
-}
-
-.personform-person-tag {
-  display: flex;
-  align-items: center;
-  gap: 0.25rem;
-  padding: 0.15rem 0.4rem;
-  background: var(--color-secondary);
-  border-radius: var(--border-radius-md);
-  font-size: 0.875rem;
-}
-
-.personform-person-tag button {
-  background: none;
-  border: none;
-  cursor: pointer;
-  padding: 0;
-  line-height: 1;
-  font-size: 1rem;
-  color: inherit;
-}
-
-.personform-person-list {
+.person-selector-list {
+  width: 100%;
+  max-height: 180px;
   position: absolute;
-  z-index: 10;
-  width: 100%;
-  margin: 0;
+  top: calc(100% + 2 * var(--border-width-md));
   padding: 0;
-  list-style: none;
-  background: var(--background-color, #fff);
-  border: var(--border-sm);
-  border-radius: var(--border-radius-md);
-  max-height: 160px;
+  border: var(--border-md);
+  background: var(--color-background);
   overflow-y: auto;
+  z-index: 1;
 }
 
-.personform-person-option {
-  padding: 0.4rem 0.5rem;
+.person-selector-option {
+  padding: 0.5rem;
   cursor: pointer;
-  font-size: 1rem;
 }
 
-.personform-person-option:hover,
-.personform-person-option.selected {
-  background: var(--color-secondary);
-}
-
-.personform-field--disabled .personform-input,
-.personform-person--disabled .personform-input {
-  opacity: 0.6;
-  background-color: var(--color-background-disabled, #f5f5f5);
-  cursor: not-allowed;
+.person-selector-option:hover,
+.person-selector-option.selected {
+  background: var(--color-secondary-light);
 }

--- a/frontend/src/components/PersonSelector/PersonSelector.tsx
+++ b/frontend/src/components/PersonSelector/PersonSelector.tsx
@@ -45,7 +45,7 @@ export default function PersonSelector({
       />
 
       {(personOpen || personSearch) && (
-        <ul className="personform-person-list">
+        <ul className="personform-person-list" role="listbox">
           {filteredPeople.length === 0 ? (
             <li className="personform-person-empty">Ei tuloksia</li>
           ) : (
@@ -53,6 +53,8 @@ export default function PersonSelector({
               <li
                 key={person.id}
                 className={`personform-person-option${selectedPersonIds.includes(String(person.id)) ? " selected" : ""}`}
+                role="option"
+                aria-selected={selectedPersonIds.includes(String(person.id))}
                 onClick={() => onSelect(person)}
               >
                 {person.firstName} {person.lastName}

--- a/frontend/src/components/PersonSelector/PersonSelector.tsx
+++ b/frontend/src/components/PersonSelector/PersonSelector.tsx
@@ -32,11 +32,11 @@ export default function PersonSelector({
   });
 
   return (
-    <div className="personform-person" ref={personRef}>
+    <div className="person-selector" ref={personRef}>
       <input
         id={inputId}
         type="text"
-        className="personform-input"
+        className="person-selector-input"
         placeholder="Hae..."
         value={personSearch}
         onFocus={onFocus}
@@ -45,14 +45,14 @@ export default function PersonSelector({
       />
 
       {(personOpen || personSearch) && (
-        <ul className="personform-person-list" role="listbox">
+        <ul className="person-selector-list" role="listbox">
           {filteredPeople.length === 0 ? (
-            <li className="personform-person-empty">Ei tuloksia</li>
+            <li className="person-selector-list-empty">Ei tuloksia</li>
           ) : (
             filteredPeople.map((person) => (
               <li
                 key={person.id}
-                className={`personform-person-option${selectedPersonIds.includes(String(person.id)) ? " selected" : ""}`}
+                className={`person-selector-option${selectedPersonIds.includes(String(person.id)) ? " selected" : ""}`}
                 role="option"
                 aria-selected={selectedPersonIds.includes(String(person.id))}
                 onClick={() => onSelect(person)}

--- a/frontend/src/components/RoomModal/RoomForm/RoomForm.css
+++ b/frontend/src/components/RoomModal/RoomForm/RoomForm.css
@@ -1,36 +1,19 @@
-.roomform-container {
-  padding: 1rem;
-  display: flex;
-  justify-content: center;
-}
-
-.roomform-form {
-  display: flex;
-  flex-direction: column;
+.room-form {
+  display: grid;
+  grid-template-columns: 1fr auto;
   gap: 0.75rem;
-  width: 100%;
-  max-width: 400px;
 }
 
-.roomform-field {
-  display: flex;
+.room-form-entry {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: subgrid;
   align-items: center;
+  gap: 2rem;
 }
 
-.roomform-label {
-  flex: 0 0 140px;
-  text-align: center;
-  margin-right: 0.5rem;
-  font-weight: 600;
-  color: var(--color-text-black);
-}
-
-.roomform-input {
-  flex: 1;
-  min-width: 0;
+.room-form-input {
   padding: 0.5rem;
   background-color: var(--color-background);
-  border: var(--border-sm);
-  border-radius: 4px;
-  font-size: 1rem;
+  border: var(--border-md);
 }

--- a/frontend/src/components/RoomModal/RoomForm/RoomForm.css
+++ b/frontend/src/components/RoomModal/RoomForm/RoomForm.css
@@ -1,7 +1,7 @@
 .room-form {
   display: grid;
   grid-template-columns: 1fr auto;
-  gap: 0.75rem;
+  gap: 0.75rem 2rem;
 }
 
 .room-form-entry {
@@ -9,11 +9,10 @@
   display: grid;
   grid-template-columns: subgrid;
   align-items: center;
-  gap: 2rem;
 }
 
 .room-form-input {
   padding: 0.5rem;
-  background-color: var(--color-background);
+  background: var(--color-background);
   border: var(--border-md);
 }

--- a/frontend/src/components/RoomModal/RoomForm/RoomForm.tsx
+++ b/frontend/src/components/RoomModal/RoomForm/RoomForm.tsx
@@ -18,15 +18,15 @@ interface FieldDef {
 const FIELDS: FieldDef[] = [
   {
     id: "capacity",
-    label: "Kapasiteetti:",
+    label: "Kapasiteetti",
     type: "number",
     required: true,
     min: 1,
     step: "1",
   },
-  { id: "roomType", label: "Huonetyyppi:", type: "select", required: true },
-  { id: "department", label: "Osasto:", type: "select", required: true },
-  { id: "freeText", label: "Lisätiedot:", type: "text", required: false },
+  { id: "roomType", label: "Huonetyyppi", type: "select", required: true },
+  { id: "department", label: "Osasto", type: "select", required: true },
+  { id: "freeText", label: "Lisätiedot", type: "text", required: false },
 ];
 
 interface SelectOptions {
@@ -50,10 +50,7 @@ function RoomForm({ initial, onChange }: RoomFormProps) {
   });
 
   useEffect(() => {
-    Promise.all([
-      findAllDepartments(),
-      findAllRoomTypes(), // Add this
-    ])
+    Promise.all([findAllDepartments(), findAllRoomTypes()])
       .then(([departments, roomTypes]) =>
         setOptions({ department: departments, roomType: roomTypes }),
       )
@@ -74,46 +71,42 @@ function RoomForm({ initial, onChange }: RoomFormProps) {
   };
 
   return (
-    <div className="roomform-container">
-      <div className="roomform-form">
-        {FIELDS.map(({ id, label, type, required, min, step }) => (
-          <div key={id} className="roomform-field">
-            <label className="roomform-label" htmlFor={id}>
-              {label}
-            </label>
-            {type === "select" ? (
-              <select
-                id={id}
-                name={id}
-                value={values[id] ?? ""}
-                onChange={handleChange}
-                required={required}
-                className="roomform-input"
-              >
-                <option value=""> Valitse </option>
-                {options[id as keyof SelectOptions].map((item) => (
-                  <option key={item.id} value={String(item.id)}>
-                    {item.name}
-                  </option>
-                ))}
-              </select>
-            ) : (
-              <input
-                id={id}
-                name={id}
-                type={type}
-                value={values[id] ?? ""}
-                onChange={handleChange}
-                required={required}
-                className="roomform-input"
-                {...(min !== undefined && { min })}
-                {...(step !== undefined && { step })}
-              />
-            )}
-          </div>
-        ))}
-      </div>
-    </div>
+    <form className="room-form">
+      {FIELDS.map(({ id, label, type, required, min, step }) => (
+        <div key={id} className="room-form-entry">
+          <label htmlFor={id}>{label}</label>
+          {type === "select" ? (
+            <select
+              id={id}
+              name={id}
+              value={values[id] ?? ""}
+              onChange={handleChange}
+              required={required}
+              className="room-form-input"
+            >
+              <option value="">Valitse</option>
+              {options[id as keyof SelectOptions].map((option) => (
+                <option key={option.id} value={String(option.id)}>
+                  {option.name}
+                </option>
+              ))}
+            </select>
+          ) : (
+            <input
+              id={id}
+              name={id}
+              type={type}
+              value={values[id] ?? ""}
+              onChange={handleChange}
+              required={required}
+              className="room-form-input"
+              {...(min !== undefined && { min })}
+              {...(step !== undefined && { step })}
+            />
+          )}
+        </div>
+      ))}
+    </form>
   );
 }
 

--- a/frontend/src/components/RoomModal/RoomModal.css
+++ b/frontend/src/components/RoomModal/RoomModal.css
@@ -1,72 +1,34 @@
 .room-modal {
-  position: relative;
-  background: var(--color-secondary);
-  border: 1px solid var(--color-secondary);
-  border-radius: var(--border-radius-md);
   padding: 0;
-  min-width: 400px;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+  border: var(--border-md);
+  background: var(--color-background);
+  box-shadow: var(--box-shadow);
 }
 
 .room-modal-content {
-  position: relative;
-  padding: var(--gap);
+  display: grid;
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.room-modal-content > header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 }
 
 .room-modal-title {
-  color: var(--color-text-black);
-  font-size: 24px;
-  margin-bottom: var(--gap);
-  margin-right: 20px;
-  text-align: center;
+  font-weight: 500;
+}
+
+.room-modal-content > header > button {
+  height: 100%;
+  aspect-ratio: 1;
 }
 
 .room-modal-actions {
-  display: flex;
-  justify-content: center;
-}
-
-.room-modal-close-button {
-  padding: 4px;
-  position: absolute;
-  top: 4px;
-  right: 4px;
-  background: transparent;
-  border: none;
-  color: var(--color-text-black);
-  cursor: pointer;
-}
-
-.room-modal-close-button:hover {
-  color: var(--color-text-white);
-}
-
-.room-modal-save-button {
-  align-items: center;
-  display: flex;
-  gap: 8px;
-  width: auto;
-  min-width: 120px;
-  justify-content: center;
-  padding: 8px 12px;
-  border: none;
-  background: var(--color-primary);
-  color: var(--color-text-white);
-  text-align: center;
-  cursor: pointer;
-  border-radius: var(--border-radius-md);
-  transition:
-    background var(--transition-fast),
-    color var(--transition-fast);
-}
-
-.room-modal-save-button:hover {
-  background: var(--color-muted);
-  color: var(--color-primary);
-}
-
-.room-modal-save-button:disabled {
-  opacity: 0.4;
-  cursor: not-allowed;
-  pointer-events: none;
+  place-self: center;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
 }

--- a/frontend/src/components/RoomModal/RoomModal.css
+++ b/frontend/src/components/RoomModal/RoomModal.css
@@ -1,23 +1,19 @@
-.roommodal-overlay {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.4);
-  z-index: 1;
-  display: grid;
-  place-items: center;
-}
-
-.roommodal-content {
+.room-modal {
   position: relative;
   background: var(--color-secondary);
   border: 1px solid var(--color-secondary);
   border-radius: var(--border-radius-md);
-  padding: var(--gap);
+  padding: 0;
   min-width: 400px;
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
 }
 
-.roommodal-title {
+.room-modal-content {
+  position: relative;
+  padding: var(--gap);
+}
+
+.room-modal-title {
   color: var(--color-text-black);
   font-size: 24px;
   margin-bottom: var(--gap);
@@ -25,12 +21,12 @@
   text-align: center;
 }
 
-.roommodal-actions {
+.room-modal-actions {
   display: flex;
   justify-content: center;
 }
 
-.roommodal-close-button {
+.room-modal-close-button {
   padding: 4px;
   position: absolute;
   top: 4px;
@@ -41,11 +37,11 @@
   cursor: pointer;
 }
 
-.roommodal-close-button:hover {
+.room-modal-close-button:hover {
   color: var(--color-text-white);
 }
 
-.roommodal-save-button {
+.room-modal-save-button {
   align-items: center;
   display: flex;
   gap: 8px;
@@ -64,12 +60,12 @@
     color var(--transition-fast);
 }
 
-.roommodal-save-button:hover {
+.room-modal-save-button:hover {
   background: var(--color-muted);
   color: var(--color-primary);
 }
 
-.roommodal-save-button:disabled {
+.room-modal-save-button:disabled {
   opacity: 0.4;
   cursor: not-allowed;
   pointer-events: none;

--- a/frontend/src/components/RoomModal/RoomModal.css
+++ b/frontend/src/components/RoomModal/RoomModal.css
@@ -17,11 +17,11 @@
   align-items: center;
 }
 
-.room-modal-title {
+.room-modal-content > header > h2 {
   font-weight: 500;
 }
 
-.room-modal-content > header > button {
+.room-modal-content > header > .button.icon {
   height: 100%;
   aspect-ratio: 1;
 }

--- a/frontend/src/components/RoomModal/RoomModal.tsx
+++ b/frontend/src/components/RoomModal/RoomModal.tsx
@@ -76,7 +76,7 @@ function RoomModal({ onClose, onSubmit, initial }: RoomModalProps) {
         </div>
 
         <ConfirmationDialog
-          open={confirmOpen}
+          isOpen={confirmOpen}
           title={
             confirmAction === "save"
               ? "Tallenna muutokset?"

--- a/frontend/src/components/RoomModal/RoomModal.tsx
+++ b/frontend/src/components/RoomModal/RoomModal.tsx
@@ -1,22 +1,43 @@
 import ConfirmationDialog from "@components/ConfirmationDialog/ConfirmationDialog";
 import { X } from "lucide-react";
-import { useCallback, useRef, useState } from "react";
+import {
+  type KeyboardEvent,
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+} from "react";
 import RoomForm from "./RoomForm/RoomForm";
 import "./RoomModal.css";
 
 interface RoomModalProps {
+  onSave: (values: Record<string, string>) => Promise<void>;
   onClose: () => void;
-  onSubmit?: (values: Record<string, string>) => void;
   initial: Record<string, string>;
 }
 
-function RoomModal({ onClose, onSubmit, initial }: RoomModalProps) {
+function RoomModal({ onSave, onClose, initial }: RoomModalProps) {
   const formDataRef = useRef<Record<string, string>>({ ...initial });
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const titleId = useId();
   const [isValid, setIsValid] = useState(false);
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [confirmAction, setConfirmAction] = useState<"save" | "close" | null>(
     null,
   );
+
+  useEffect(() => {
+    dialogRef.current?.showModal();
+  }, []);
+
+  const handleEscape = (e: KeyboardEvent<HTMLDialogElement>) => {
+    if (e.key !== "Escape") return;
+
+    e.preventDefault();
+    e.stopPropagation();
+    requestClose();
+  };
 
   const handleFormChange = useCallback(
     (values: Record<string, string>, valid: boolean) => {
@@ -26,11 +47,22 @@ function RoomModal({ onClose, onSubmit, initial }: RoomModalProps) {
     [],
   );
 
-  const handleSave = () => {
-    onSubmit?.(formDataRef.current);
+  const handleSave = async () => {
+    await onSave(formDataRef.current);
+  };
+
+  const handleClose = () => {
+    dialogRef.current?.close();
     onClose();
   };
 
+  const handleClick = (e: React.PointerEvent<HTMLDialogElement>) => {
+    if (e.target === e.currentTarget) {
+      requestClose();
+    }
+  };
+
+  // Open confirm dialog
   const requestSave = () => {
     setConfirmAction("save");
     setConfirmOpen(true);
@@ -40,43 +72,60 @@ function RoomModal({ onClose, onSubmit, initial }: RoomModalProps) {
     setConfirmOpen(true);
   };
 
-  const handleConfirm = () => {
+  // Handle confirm dialog
+  const handleConfirmConfirm = async () => {
     setConfirmOpen(false);
-    if (confirmAction === "save") handleSave();
-    if (confirmAction === "close") onClose();
+    if (confirmAction === "save") {
+      try {
+        await handleSave();
+        handleClose();
+      } catch (error) {
+        console.error("Failed to save room:", error);
+      }
+    }
+    if (confirmAction === "close") handleClose();
     setConfirmAction(null);
   };
-  const handleCancel = () => {
+  const handleConfirmClose = () => {
     setConfirmOpen(false);
     setConfirmAction(null);
   };
 
   return (
-    <div className="roommodal-overlay" onClick={requestClose}>
-      <div className="roommodal-content" onClick={(e) => e.stopPropagation()}>
+    <dialog
+      ref={dialogRef}
+      className="room-modal"
+      aria-labelledby={titleId}
+      onKeyDown={handleEscape}
+      onClick={handleClick}
+    >
+      <div className="room-modal-content">
         <button
-          className="roommodal-close-button"
+          className="room-modal-close-button"
           aria-label="Sulje huoneen tietojen muokkaus"
           onClick={requestClose}
         >
           <X size={16} />
         </button>
-        <h2 className="roommodal-title">Muokkaa huonetta</h2>
+        <h2 id={titleId} className="room-modal-title">
+          Muokkaa huonetta
+        </h2>
 
         <RoomForm onChange={handleFormChange} initial={initial} />
 
-        <div className="roommodal-actions">
+        <div className="room-modal-actions">
           <button
-            className="roommodal-save-button"
+            className="room-modal-save-button"
             onClick={requestSave}
             disabled={!isValid}
           >
             Tallenna
           </button>
         </div>
+      </div>
 
+      {confirmOpen && (
         <ConfirmationDialog
-          isOpen={confirmOpen}
           title={
             confirmAction === "save"
               ? "Tallenna muutokset?"
@@ -84,11 +133,11 @@ function RoomModal({ onClose, onSubmit, initial }: RoomModalProps) {
           }
           confirmText={confirmAction === "save" ? "Tallenna" : "Kyllä"}
           cancelText="Peruuta"
-          onConfirm={handleConfirm}
-          onCancel={handleCancel}
+          onConfirm={() => void handleConfirmConfirm()}
+          onClose={handleConfirmClose}
         />
-      </div>
-    </div>
+      )}
+    </dialog>
   );
 }
 

--- a/frontend/src/components/RoomModal/RoomModal.tsx
+++ b/frontend/src/components/RoomModal/RoomModal.tsx
@@ -100,26 +100,27 @@ function RoomModal({ onSave, onClose, initial }: RoomModalProps) {
       onClick={handleClick}
     >
       <div className="room-modal-content">
-        <button
-          className="room-modal-close-button"
-          aria-label="Sulje huoneen tietojen muokkaus"
-          onClick={requestClose}
-        >
-          <X size={16} />
-        </button>
-        <h2 id={titleId} className="room-modal-title">
-          Muokkaa huonetta
-        </h2>
+        <header>
+          <h2 id={titleId} className="room-modal-title">
+            Muokkaa huonetta
+          </h2>
+          <button
+            className="button icon"
+            aria-label="Sulje huoneen tietojen muokkaus"
+            onClick={requestClose}
+          >
+            <X size={20} />
+          </button>
+        </header>
 
         <RoomForm onChange={handleFormChange} initial={initial} />
 
         <div className="room-modal-actions">
-          <button
-            className="room-modal-save-button"
-            onClick={requestSave}
-            disabled={!isValid}
-          >
+          <button className="button" onClick={requestSave} disabled={!isValid}>
             Tallenna
+          </button>
+          <button className="button" onClick={requestClose}>
+            Peruuta
           </button>
         </div>
       </div>

--- a/frontend/src/components/Sidepanel/RoomInfo/RoomInfo.tsx
+++ b/frontend/src/components/Sidepanel/RoomInfo/RoomInfo.tsx
@@ -30,19 +30,15 @@ function RoomInfo({ onRoomUpdate }: RoomInfoProps) {
 
   const toggleDetails = () => setDetailsCollapsed((previous) => !previous);
 
-  const handleEditRoom = async (values: Record<string, string>) => {
-    if (roomId == null) return;
-    try {
-      await editRoom(roomId, values);
-      void onRoomUpdate();
-      void selectRoom(roomId);
-    } catch (error) {
-      console.error("Failed to edit room:", error);
-    }
+  const handleEditRoomClose = () => {
+    setEditRoomOpen(false);
   };
 
-  const submitEditRoom = (values: Record<string, string>) => {
-    void handleEditRoom(values);
+  const handleEditRoomSave = async (values: Record<string, string>) => {
+    if (roomId == null) return;
+    await editRoom(roomId, values);
+    void onRoomUpdate();
+    void selectRoom(roomId);
   };
 
   return (
@@ -153,8 +149,8 @@ function RoomInfo({ onRoomUpdate }: RoomInfoProps) {
       {/* Edit Room Modal */}
       {editRoomOpen && isLoaded && (
         <RoomModal
-          onClose={() => setEditRoomOpen(false)}
-          onSubmit={submitEditRoom}
+          onClose={handleEditRoomClose}
+          onSave={handleEditRoomSave}
           initial={{
             capacity: String(activeRoom.capacity ?? ""),
             roomType: String(activeRoom.roomType?.id ?? ""),

--- a/frontend/src/components/Sidepanel/RoomInfo/RoomInfo.tsx
+++ b/frontend/src/components/Sidepanel/RoomInfo/RoomInfo.tsx
@@ -60,7 +60,7 @@ function RoomInfo({ onRoomUpdate }: RoomInfoProps) {
           })}
         </h2>
         <button
-          className="button-icon"
+          className="button icon"
           onClick={toggleDetails}
           aria-label={
             detailsCollapsed ? "Avaa huoneen tiedot" : "Sulje huoneen tiedot"
@@ -74,14 +74,14 @@ function RoomInfo({ onRoomUpdate }: RoomInfoProps) {
           />
         </button>
         <button
-          className="button-icon"
+          className="button icon"
           aria-label="Muokkaa huoneen tietoja"
           onClick={() => setEditRoomOpen(true)}
         >
           <SquarePen />
         </button>
         <button
-          className="button-icon"
+          className="button icon"
           aria-label="Sulje huone"
           onClick={() => void selectRoom(null)}
         >

--- a/frontend/src/components/Sidepanel/RoomPeople/RoomPeople.tsx
+++ b/frontend/src/components/Sidepanel/RoomPeople/RoomPeople.tsx
@@ -110,9 +110,13 @@ function RoomPeople({ onRoomUpdate }: RoomPeopleProps) {
     seenExpandReqId = expandReq.reqId;
   }, [activeRoom?.contracts, expandReq, state.contractsCollapsed]);
 
+  const handlePersonModalClose = () => {
+    dispatch({ type: "close-person-modal" });
+  };
+
   const submitPerson = async (values: Record<string, string>) => {
     if (!activeRoomId) {
-      return new Error("No active room selected");
+      throw new Error("No room selected");
     }
 
     try {
@@ -128,20 +132,16 @@ function RoomPeople({ onRoomUpdate }: RoomPeopleProps) {
       } else {
         await addPerson(values, activeRoomId);
       }
-
-      dispatch({ type: "close-person-modal" });
-      void onRoomUpdate();
-      void selectRoom(activeRoomId);
     } catch (error) {
       console.error(
         state.activePerson ? "Failed to edit person:" : "Failed to add person:",
         error,
       );
+      throw error;
     }
-  };
 
-  const handlePersonSubmit = (values: Record<string, string>) => {
-    void submitPerson(values);
+    void onRoomUpdate();
+    void selectRoom(activeRoomId);
   };
 
   const handleRemoveContract = async () => {
@@ -249,10 +249,8 @@ function RoomPeople({ onRoomUpdate }: RoomPeopleProps) {
       {/* Person Modal */}
       {state.addPersonOpen && (
         <PersonModal
-          onClose={() => {
-            dispatch({ type: "close-person-modal" });
-          }}
-          onSubmit={handlePersonSubmit}
+          onSave={submitPerson}
+          onClose={handlePersonModalClose}
           initial={
             state.activePerson
               ? {
@@ -282,14 +280,16 @@ function RoomPeople({ onRoomUpdate }: RoomPeopleProps) {
       )}
 
       {/* Confirmation Button */}
-      <ConfirmationDialog
-        isOpen={state.contractToRemove !== null}
-        title={`Poista ${state.contractToRemove?.person.firstName} ${state.contractToRemove?.person.lastName}?`}
-        confirmText="Poista"
-        cancelText="Peruuta"
-        onConfirm={() => void handleRemoveContract()}
-        onCancel={() => dispatch({ type: "cancel-remove-contract" })}
-      />
+
+      {state.contractToRemove && (
+        <ConfirmationDialog
+          title={`Poista ${state.contractToRemove?.person.firstName} ${state.contractToRemove?.person.lastName}?`}
+          confirmText="Poista"
+          cancelText="Peruuta"
+          onConfirm={() => void handleRemoveContract()}
+          onClose={() => dispatch({ type: "cancel-remove-contract" })}
+        />
+      )}
     </section>
   );
 }

--- a/frontend/src/components/Sidepanel/RoomPeople/RoomPeople.tsx
+++ b/frontend/src/components/Sidepanel/RoomPeople/RoomPeople.tsx
@@ -178,7 +178,7 @@ function RoomPeople({ onRoomUpdate }: RoomPeopleProps) {
           )}
         </h2>
         <button
-          className="button-icon"
+          className="button icon"
           onClick={() => dispatch({ type: "toggle-contracts" })}
           aria-label={
             state.contractsCollapsed
@@ -196,7 +196,7 @@ function RoomPeople({ onRoomUpdate }: RoomPeopleProps) {
           />
         </button>
         <button
-          className="button-icon"
+          className="button icon"
           aria-label="Sijoita henkilö huoneeseen"
           onClick={() => dispatch({ type: "open-add-person" })}
         >
@@ -283,7 +283,7 @@ function RoomPeople({ onRoomUpdate }: RoomPeopleProps) {
 
       {/* Confirmation Button */}
       <ConfirmationDialog
-        open={state.contractToRemove !== null}
+        isOpen={state.contractToRemove !== null}
         title={`Poista ${state.contractToRemove?.person.firstName} ${state.contractToRemove?.person.lastName}?`}
         confirmText="Poista"
         cancelText="Peruuta"

--- a/frontend/src/components/Sidepanel/RoomPeople/RoomPersonCard/RoomPersonCard.tsx
+++ b/frontend/src/components/Sidepanel/RoomPeople/RoomPersonCard/RoomPersonCard.tsx
@@ -76,7 +76,7 @@ function RoomPersonCard({ contract, onEdit, onRemove }: RoomPersonCardProps) {
             {contract.person.lastName} {contract.person.firstName}
           </h3>
           <button
-            className="button-icon"
+            className="button icon"
             onClick={toggleDetails}
             aria-label={
               detailsCollapsed
@@ -93,14 +93,14 @@ function RoomPersonCard({ contract, onEdit, onRemove }: RoomPersonCardProps) {
             />
           </button>
           <button
-            className="button-icon"
+            className="button icon"
             aria-label="Muokkaa henkilön tietoja"
             onClick={onEdit}
           >
             <Pencil size={18} />
           </button>
           <button
-            className="button-icon"
+            className="button icon"
             aria-label="Poista henkilö"
             onClick={onRemove}
           >

--- a/frontend/src/components/Sidepanel/SidePanel.css
+++ b/frontend/src/components/Sidepanel/SidePanel.css
@@ -11,7 +11,7 @@
   gap: 2px;
   border: var(--border-md);
   background: var(--color-text-black);
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 
 .side-panel > section {

--- a/frontend/src/components/TopBar/SettingsModal/SettingsModal.css
+++ b/frontend/src/components/TopBar/SettingsModal/SettingsModal.css
@@ -1,48 +1,33 @@
-.settings-overlay {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.4);
-  display: grid;
-  place-items: center;
+.settings-modal {
+  min-width: 300px;
+  gap: 0.5rem;
+  background: var(--color-background);
+  border: var(--border-md);
+  padding: var(--gap);
+  box-shadow: var(--box-shadow);
   z-index: 2;
 }
 
-.settings-modal {
-  position: relative;
-  background: var(--color-background);
-  border: var(--border-sm);
-  border-radius: var(--border-radius-md);
-  padding: var(--gap);
-  min-width: 280px;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+.settings-modal[open] {
+  display: grid;
 }
 
-.settings-modal-title {
-  color: var(--color-text-black);
-  font-size: 16px;
-  margin-bottom: var(--gap);
-  margin-right: 20px;
-}
-
-.settings-modal-row {
+.settings-modal > header {
   display: flex;
-  flex-direction: column;
-  gap: 8px;
-  color: var(--color-text-black);
-  font-size: 14px;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.settings-modal > header > h2 {
+  font-weight: 500;
 }
 
 .settings-modal-close-button {
-  padding: 4px;
-  position: absolute;
-  top: 4px;
-  right: 4px;
-  background: transparent;
-  border: none;
-  color: var(--color-text-black);
-  cursor: pointer;
+  aspect-ratio: 1;
+  height: 100%;
 }
 
-.settings-modal-close-button:hover {
-  color: var(--color-primary);
+.settings-entry {
+  display: grid;
+  gap: 0.5rem;
 }

--- a/frontend/src/components/TopBar/SettingsModal/SettingsModal.tsx
+++ b/frontend/src/components/TopBar/SettingsModal/SettingsModal.tsx
@@ -70,7 +70,7 @@ function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
         <h2 id={titleId}>Asetukset</h2>
         <button
           type="button"
-          className="button-icon settings-modal-close-button"
+          className="button icon settings-modal-close-button"
           aria-label="Sulje asetukset"
           onClick={onClose}
         >

--- a/frontend/src/components/TopBar/SettingsModal/SettingsModal.tsx
+++ b/frontend/src/components/TopBar/SettingsModal/SettingsModal.tsx
@@ -8,7 +8,7 @@ const ROOM_LABEL_FONT_SIZE_MAX = 32;
 
 function getStoredFontSize() {
   try {
-    const storedValue = localStorage.getItem("map-font-size");
+    const storedValue = localStorage.getItem("font-size-map");
     if (!storedValue) {
       return ROOM_LABEL_FONT_SIZE_DEFAULT;
     }
@@ -52,7 +52,7 @@ function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
 
   // Update font size
   useEffect(() => {
-    localStorage.setItem("map-font-size", String(fontSize));
+    localStorage.setItem("font-size-map", String(fontSize));
     document.documentElement.style.setProperty(
       "--font-size-map",
       `${fontSize}px`,
@@ -69,7 +69,6 @@ function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
       <header>
         <h2 id={titleId}>Asetukset</h2>
         <button
-          type="button"
           className="button icon settings-modal-close-button"
           aria-label="Sulje asetukset"
           onClick={onClose}

--- a/frontend/src/components/TopBar/SettingsModal/SettingsModal.tsx
+++ b/frontend/src/components/TopBar/SettingsModal/SettingsModal.tsx
@@ -1,47 +1,99 @@
 import { X } from "lucide-react";
+import { useEffect, useId, useRef, useState } from "react";
 import "./SettingsModal.css";
 
+const ROOM_LABEL_FONT_SIZE_DEFAULT = 24;
 const ROOM_LABEL_FONT_SIZE_MIN = 10;
 const ROOM_LABEL_FONT_SIZE_MAX = 32;
 
-interface SettingsModalProps {
-  onClose: () => void;
-  fontSize: number;
-  setFontSize: (size: number) => void;
+function getStoredFontSize() {
+  try {
+    const storedValue = localStorage.getItem("map-font-size");
+    if (!storedValue) {
+      return ROOM_LABEL_FONT_SIZE_DEFAULT;
+    }
+
+    const parsedValue = Number(storedValue);
+    if (Number.isNaN(parsedValue)) {
+      return ROOM_LABEL_FONT_SIZE_DEFAULT;
+    }
+
+    return parsedValue;
+  } catch {
+    return ROOM_LABEL_FONT_SIZE_DEFAULT;
+  }
 }
 
-function SettingsModal({ onClose, fontSize, setFontSize }: SettingsModalProps) {
+interface SettingsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
+  const [fontSize, setFontSize] = useState(getStoredFontSize);
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const titleId = useId();
+
+  // Toggle dialog
+  useEffect(() => {
+    const dialogElement = dialogRef.current;
+    if (!dialogElement) {
+      return;
+    }
+
+    if (isOpen && !dialogElement.open) {
+      dialogElement.showModal();
+    }
+
+    if (!isOpen && dialogElement.open) {
+      dialogElement.close();
+    }
+  }, [isOpen]);
+
+  // Update font size
+  useEffect(() => {
+    localStorage.setItem("map-font-size", String(fontSize));
+    document.documentElement.style.setProperty(
+      "--font-size-map",
+      `${fontSize}px`,
+    );
+  }, [fontSize]);
+
   return (
-    <div className="settings-overlay" onClick={onClose}>
-      <div className="settings-modal" onClick={(e) => e.stopPropagation()}>
+    <dialog
+      ref={dialogRef}
+      className="settings-modal"
+      onClose={onClose}
+      aria-labelledby={titleId}
+    >
+      <header>
+        <h2 id={titleId}>Asetukset</h2>
         <button
-          className="settings-modal-close-button"
+          type="button"
+          className="button-icon settings-modal-close-button"
           aria-label="Sulje asetukset"
           onClick={onClose}
         >
           <X size={16} />
         </button>
-        <h2 className="settings-modal-title">Asetukset</h2>
-        <div className="settings-modal-row">
-          <label>Kartan tekstin fonttikoko: {fontSize}px</label>
-          <input
-            type="range"
-            min={ROOM_LABEL_FONT_SIZE_MIN}
-            max={ROOM_LABEL_FONT_SIZE_MAX}
-            value={fontSize}
-            onChange={(e) => {
-              const size = Number(e.target.value);
-              setFontSize(size);
-              localStorage.setItem("font-size-map", String(size));
-              document.documentElement.style.setProperty(
-                "--font-size-map",
-                `${size}px`,
-              );
-            }}
-          />
-        </div>
+      </header>
+      <div className="settings-entry">
+        <label htmlFor="font-size-input">
+          Kartan tekstin fonttikoko: {fontSize}px
+        </label>
+        <input
+          id="font-size-input"
+          type="range"
+          min={ROOM_LABEL_FONT_SIZE_MIN}
+          max={ROOM_LABEL_FONT_SIZE_MAX}
+          value={fontSize}
+          onChange={(e) => {
+            const size = Number(e.target.value);
+            setFontSize(size);
+          }}
+        />
       </div>
-    </div>
+    </dialog>
   );
 }
 

--- a/frontend/src/components/TopBar/SettingsModal/SettingsModal.tsx
+++ b/frontend/src/components/TopBar/SettingsModal/SettingsModal.tsx
@@ -1,5 +1,5 @@
 import { X } from "lucide-react";
-import { useEffect, useId, useRef, useState } from "react";
+import { type KeyboardEvent, useEffect, useId, useRef, useState } from "react";
 import "./SettingsModal.css";
 
 const ROOM_LABEL_FONT_SIZE_DEFAULT = 24;
@@ -25,32 +25,30 @@ function getStoredFontSize() {
 }
 
 interface SettingsModalProps {
-  isOpen: boolean;
   onClose: () => void;
 }
 
-function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
+function SettingsModal({ onClose }: SettingsModalProps) {
   const [fontSize, setFontSize] = useState(getStoredFontSize);
   const dialogRef = useRef<HTMLDialogElement>(null);
   const titleId = useId();
 
-  // Toggle dialog
   useEffect(() => {
-    const dialogElement = dialogRef.current;
-    if (!dialogElement) {
-      return;
-    }
+    dialogRef.current?.showModal();
+  }, []);
 
-    if (isOpen && !dialogElement.open) {
-      dialogElement.showModal();
-    }
+  const handleEscape = (e: KeyboardEvent<HTMLDialogElement>) => {
+    if (e.key !== "Escape") return;
+    e.preventDefault();
+    e.stopPropagation();
+    handleClose();
+  };
 
-    if (!isOpen && dialogElement.open) {
-      dialogElement.close();
-    }
-  }, [isOpen]);
+  const handleClose = () => {
+    dialogRef.current?.close();
+    onClose();
+  };
 
-  // Update font size
   useEffect(() => {
     localStorage.setItem("font-size-map", String(fontSize));
     document.documentElement.style.setProperty(
@@ -63,15 +61,15 @@ function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
     <dialog
       ref={dialogRef}
       className="settings-modal"
-      onClose={onClose}
       aria-labelledby={titleId}
+      onKeyDown={handleEscape}
     >
       <header>
         <h2 id={titleId}>Asetukset</h2>
         <button
           className="button icon settings-modal-close-button"
           aria-label="Sulje asetukset"
-          onClick={onClose}
+          onClick={handleClose}
         >
           <X size={16} />
         </button>

--- a/frontend/src/components/TopBar/TopBar.css
+++ b/frontend/src/components/TopBar/TopBar.css
@@ -23,21 +23,3 @@
   display: flex;
   gap: var(--border-width-md);
 }
-
-.topbar-buttons > button {
-  aspect-ratio: 1;
-  display: grid;
-  place-content: center;
-  border: none;
-  padding: 0;
-  background: var(--color-primary);
-  color: var(--color-text-black);
-  cursor: pointer;
-  transition:
-    background-color var(--transition-fast);
-}
-
-.topbar-buttons > button:hover {
-  background: var(--color-primary-light);
-  color: var(--color-text-black);
-}

--- a/frontend/src/components/TopBar/TopBar.tsx
+++ b/frontend/src/components/TopBar/TopBar.tsx
@@ -15,6 +15,7 @@ function TopBar() {
       <PersonSearch />
       <div className="topbar-buttons">
         <button
+          className="button square-icon"
           aria-label="Asetukset"
           onClick={() => {
             setSettingsOpen((v) => !v);
@@ -23,6 +24,7 @@ function TopBar() {
           <Settings strokeWidth={1.7} />
         </button>
         <button
+          className="button square-icon"
           aria-label="Käyttäjä"
           onMouseDown={(event) => {
             event.stopPropagation();

--- a/frontend/src/components/TopBar/TopBar.tsx
+++ b/frontend/src/components/TopBar/TopBar.tsx
@@ -1,25 +1,13 @@
 import PersonSearch from "@components/PersonSearch/PersonSearch";
 import { Settings, User } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import SettingsModal from "./SettingsModal/SettingsModal";
 import "./TopBar.css";
 import UserMenu from "./UserMenu/UserMenu";
 
-const ROOM_LABEL_FONT_SIZE = 24;
-
 function TopBar() {
   const [userMenuOpen, setUserMenuOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
-  const [fontSize, setFontSize] = useState(
-    Number(localStorage.getItem("font-size-map")) || ROOM_LABEL_FONT_SIZE,
-  );
-
-  useEffect(() => {
-    document.documentElement.style.setProperty(
-      "--font-size-map",
-      `${fontSize}px`,
-    );
-  }, [fontSize]);
 
   return (
     <header className="topbar">
@@ -47,13 +35,10 @@ function TopBar() {
         </button>
         {userMenuOpen && <UserMenu onClose={() => setUserMenuOpen(false)} />}
       </div>
-      {settingsOpen && (
-        <SettingsModal
-          onClose={() => setSettingsOpen(false)}
-          fontSize={fontSize}
-          setFontSize={setFontSize}
-        />
-      )}
+      <SettingsModal
+        isOpen={settingsOpen}
+        onClose={() => setSettingsOpen(false)}
+      />
     </header>
   );
 }

--- a/frontend/src/components/TopBar/TopBar.tsx
+++ b/frontend/src/components/TopBar/TopBar.tsx
@@ -37,10 +37,7 @@ function TopBar() {
         </button>
         {userMenuOpen && <UserMenu onClose={() => setUserMenuOpen(false)} />}
       </div>
-      <SettingsModal
-        isOpen={settingsOpen}
-        onClose={() => setSettingsOpen(false)}
-      />
+      {settingsOpen && <SettingsModal onClose={() => setSettingsOpen(false)} />}
     </header>
   );
 }

--- a/frontend/src/components/TopBar/UserMenu/UserMenu.css
+++ b/frontend/src/components/TopBar/UserMenu/UserMenu.css
@@ -18,14 +18,3 @@
   place-items: center;
   gap: 0.5rem;
 }
-
-.button-logout {
-  justify-self: end;
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.25rem 0.5rem;
-  border: var(--border-md);
-  background: var(--color-primary);
-  cursor: pointer;
-}

--- a/frontend/src/components/TopBar/UserMenu/UserMenu.tsx
+++ b/frontend/src/components/TopBar/UserMenu/UserMenu.tsx
@@ -26,14 +26,14 @@ function UserMenu({ onClose }: UserMenuProps) {
       <header>
         <h2>{user ? user.name : "Ei käyttäjää"}</h2>
         <button
-          className="button-icon button-close"
+          className="button icon button-close"
           aria-label="Sulje käyttäjävalikko"
           onClick={onClose}
         >
           <X size={20} />
         </button>
       </header>
-      <button className="button-logout" onClick={() => void logout()}>
+      <button className="button combined" onClick={() => void logout()}>
         <LogOut size={20} />
         Kirjaudu ulos
       </button>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -53,6 +53,10 @@ body {
   grid-template-rows: auto 1fr;
 }
 
+dialog::backdrop {
+  background: rgba(0, 0, 0, 0.4);
+}
+
 h1,
 h2,
 h3,

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -82,6 +82,12 @@ h6 {
     background: var(--color-primary-light);
   }
 
+  &:disabled {
+    background: var(--color-muted);
+    color: var(--color-text-white);
+    cursor: not-allowed;
+  }
+
   &.combined {
     display: inline-flex;
     align-items: center;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -53,6 +53,10 @@ body {
   grid-template-rows: auto 1fr;
 }
 
+dialog {
+  color: var(--color-text-black);
+}
+
 dialog::backdrop {
   background: rgba(0, 0, 0, 0.4);
 }
@@ -66,13 +70,31 @@ h6 {
   font: unset;
 }
 
-.button-icon {
-  display: grid;
-  place-items: center;
-  background: transparent;
-  border: none;
-  padding: 0;
+.button {
+  padding: 0.25rem 0.5rem;
+  border: var(--border-md);
+  background: var(--color-primary);
   cursor: pointer;
+  transition:
+    background-color var(--transition-fast) linear;
+
+  &:hover {
+    background: var(--color-primary-light);
+  }
+
+  &.combined {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  &.icon {
+    display: grid;
+    place-items: center;
+    background: transparent;
+    border: none;
+    padding: 0;
+  }
 }
 
 .no-data {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -95,6 +95,21 @@ h6 {
     border: none;
     padding: 0;
   }
+
+  &.square-icon {
+    aspect-ratio: 1;
+    display: grid;
+    place-content: center;
+    border: none;
+    padding: 0;
+    background: var(--color-primary);
+    color: var(--color-text-black);
+
+    &:hover {
+      background: var(--color-primary-light);
+      color: var(--color-text-black);
+    }
+  }
 }
 
 .no-data {

--- a/frontend/tests/components/personForm.test.tsx
+++ b/frontend/tests/components/personForm.test.tsx
@@ -47,27 +47,27 @@ describe("PersonForm", () => {
 
   it("renders without crashing", () => {
     render(<PersonForm {...defaultProps} />);
-    expect(screen.getByLabelText("Etunimi:")).toBeInTheDocument();
+    expect(screen.getByLabelText("Etunimi")).toBeInTheDocument();
   });
 
   it("renders all fields", () => {
     render(<PersonForm {...defaultProps} />);
-    expect(screen.getByLabelText("Etunimi:")).toBeInTheDocument();
-    expect(screen.getByLabelText("Sukunimi:")).toBeInTheDocument();
-    expect(screen.getByLabelText("Osasto:")).toBeInTheDocument();
-    expect(screen.getByLabelText("Työnimike:")).toBeInTheDocument();
-    expect(screen.getByLabelText("Esihenkilö(t):")).toBeInTheDocument();
-    expect(screen.getByLabelText("Sopimuksen alku:")).toBeInTheDocument();
-    expect(screen.getByLabelText("Sopimuksen loppu:")).toBeInTheDocument();
-    expect(screen.getByLabelText("Tutkimusryhmä:")).toBeInTheDocument();
-    expect(screen.getByLabelText("Muut tiedot:")).toBeInTheDocument();
+    expect(screen.getByLabelText("Etunimi")).toBeInTheDocument();
+    expect(screen.getByLabelText("Sukunimi")).toBeInTheDocument();
+    expect(screen.getByLabelText("Osasto")).toBeInTheDocument();
+    expect(screen.getByLabelText("Työnimike")).toBeInTheDocument();
+    expect(screen.getByLabelText("Esihenkilö(t)")).toBeInTheDocument();
+    expect(screen.getByLabelText("Sopimuksen alku")).toBeInTheDocument();
+    expect(screen.getByLabelText("Sopimuksen loppu")).toBeInTheDocument();
+    expect(screen.getByLabelText("Tutkimusryhmä")).toBeInTheDocument();
+    expect(screen.getByLabelText("Muut tiedot")).toBeInTheDocument();
   });
 
   it("renders with empty fields by default", () => {
     render(<PersonForm {...defaultProps} />);
-    expect(screen.getByLabelText("Etunimi:")).toHaveValue("");
-    expect(screen.getByLabelText("Sukunimi:")).toHaveValue("");
-    expect(screen.getByLabelText("Osasto:")).toHaveValue("");
+    expect(screen.getByLabelText("Etunimi")).toHaveValue("");
+    expect(screen.getByLabelText("Sukunimi")).toHaveValue("");
+    expect(screen.getByLabelText("Osasto")).toHaveValue("");
   });
 
   it("renders with initial text values pre-filled", () => {
@@ -88,7 +88,7 @@ describe("PersonForm", () => {
 
   it("calls onChange with updated values when a text field changes", () => {
     render(<PersonForm {...defaultProps} />);
-    fireEvent.change(screen.getByLabelText("Etunimi:"), {
+    fireEvent.change(screen.getByLabelText("Etunimi"), {
       target: { value: "Matti" },
     });
     expect(defaultProps.onChange).toHaveBeenCalledWith(
@@ -101,7 +101,7 @@ describe("PersonForm", () => {
     const user = userEvent.setup();
     render(<PersonForm {...defaultProps} initial={REQUIRED_INITIAL} />);
 
-    const select = screen.getByLabelText("Osasto:");
+    const select = screen.getByLabelText("Osasto");
     const option = await screen.findByRole("option", { name: "HR" });
     await user.selectOptions(select, option);
 
@@ -114,10 +114,10 @@ describe("PersonForm", () => {
 
   it("reports valid when all required fields are filled", () => {
     render(<PersonForm {...defaultProps} />);
-    fireEvent.change(screen.getByLabelText("Etunimi:"), {
+    fireEvent.change(screen.getByLabelText("Etunimi"), {
       target: { value: "Terppa" },
     });
-    fireEvent.change(screen.getByLabelText("Sukunimi:"), {
+    fireEvent.change(screen.getByLabelText("Sukunimi"), {
       target: { value: "Testaaja" },
     });
     expect(defaultProps.onChange).toHaveBeenLastCalledWith(
@@ -128,7 +128,7 @@ describe("PersonForm", () => {
 
   it("reports invalid when a required field is cleared", () => {
     render(<PersonForm {...defaultProps} initial={REQUIRED_INITIAL} />);
-    fireEvent.change(screen.getByLabelText("Etunimi:"), {
+    fireEvent.change(screen.getByLabelText("Etunimi"), {
       target: { value: "" },
     });
     expect(defaultProps.onChange).toHaveBeenLastCalledWith(
@@ -139,7 +139,7 @@ describe("PersonForm", () => {
 
   it("reports invalid when a required field is only whitespace", () => {
     render(<PersonForm {...defaultProps} initial={REQUIRED_INITIAL} />);
-    fireEvent.change(screen.getByLabelText("Etunimi:"), {
+    fireEvent.change(screen.getByLabelText("Etunimi"), {
       target: { value: "   " },
     });
     expect(defaultProps.onChange).toHaveBeenLastCalledWith(
@@ -150,7 +150,7 @@ describe("PersonForm", () => {
 
   it("optional fields do not affect validity", () => {
     render(<PersonForm {...defaultProps} initial={REQUIRED_INITIAL} />);
-    fireEvent.change(screen.getByLabelText("Muut tiedot:"), {
+    fireEvent.change(screen.getByLabelText("Muut tiedot"), {
       target: { value: "" },
     });
     expect(defaultProps.onChange).toHaveBeenLastCalledWith(
@@ -161,10 +161,10 @@ describe("PersonForm", () => {
 
   it("date fields accept date values", () => {
     render(<PersonForm {...defaultProps} initial={REQUIRED_INITIAL} />);
-    fireEvent.change(screen.getByLabelText("Sopimuksen alku:"), {
+    fireEvent.change(screen.getByLabelText("Sopimuksen alku"), {
       target: { value: "2025-01-01" },
     });
-    fireEvent.change(screen.getByLabelText("Sopimuksen loppu:"), {
+    fireEvent.change(screen.getByLabelText("Sopimuksen loppu"), {
       target: { value: "2026-01-01" },
     });
     expect(defaultProps.onChange).toHaveBeenLastCalledWith(
@@ -194,7 +194,7 @@ describe("PersonForm", () => {
     await waitFor(() =>
       expect(screen.getByRole("option", { name: "IT" })).toBeInTheDocument(),
     );
-    fireEvent.focus(screen.getByLabelText("Esihenkilö(t):"));
+    fireEvent.focus(screen.getByLabelText("Esihenkilö(t)"));
     expect(screen.getByText("Joku Esihenkilö")).toBeInTheDocument();
   });
 
@@ -203,8 +203,8 @@ describe("PersonForm", () => {
     await waitFor(() =>
       expect(screen.getByRole("option", { name: "IT" })).toBeInTheDocument(),
     );
-    fireEvent.focus(screen.getByLabelText("Esihenkilö(t):"));
-    fireEvent.change(screen.getByLabelText("Esihenkilö(t):"), {
+    fireEvent.focus(screen.getByLabelText("Esihenkilö(t)"));
+    fireEvent.change(screen.getByLabelText("Esihenkilö(t)"), {
       target: { value: "Joku" },
     });
     expect(screen.getByText("Joku Esihenkilö")).toBeInTheDocument();
@@ -216,7 +216,7 @@ describe("PersonForm", () => {
     await waitFor(() =>
       expect(screen.getByRole("option", { name: "IT" })).toBeInTheDocument(),
     );
-    fireEvent.change(screen.getByLabelText("Esihenkilö(t):"), {
+    fireEvent.change(screen.getByLabelText("Esihenkilö(t)"), {
       target: { value: "zzznomatch" },
     });
     expect(screen.getByText("Ei tuloksia")).toBeInTheDocument();
@@ -227,7 +227,7 @@ describe("PersonForm", () => {
     await waitFor(() =>
       expect(screen.getByRole("option", { name: "IT" })).toBeInTheDocument(),
     );
-    fireEvent.focus(screen.getByLabelText("Esihenkilö(t):"));
+    fireEvent.focus(screen.getByLabelText("Esihenkilö(t)"));
     fireEvent.click(screen.getByText("Joku Esihenkilö"));
     expect(screen.getByLabelText("Poista Joku Esihenkilö")).toBeInTheDocument();
   });
@@ -238,10 +238,10 @@ describe("PersonForm", () => {
       expect(screen.getByRole("option", { name: "IT" })).toBeInTheDocument(),
     );
     // Select
-    fireEvent.focus(screen.getByLabelText("Esihenkilö(t):"));
+    fireEvent.focus(screen.getByLabelText("Esihenkilö(t)"));
     fireEvent.click(screen.getByText("Joku Esihenkilö"));
     // Reopen and click the list item specifically to deselect
-    fireEvent.focus(screen.getByLabelText("Esihenkilö(t):"));
+    fireEvent.focus(screen.getByLabelText("Esihenkilö(t)"));
     const listItem = screen
       .getAllByText("Joku Esihenkilö")
       .find((el) => el.tagName === "LI")!;
@@ -256,7 +256,7 @@ describe("PersonForm", () => {
     await waitFor(() =>
       expect(screen.getByRole("option", { name: "IT" })).toBeInTheDocument(),
     );
-    fireEvent.focus(screen.getByLabelText("Esihenkilö(t):"));
+    fireEvent.focus(screen.getByLabelText("Esihenkilö(t)"));
     fireEvent.click(screen.getByText("Joku Esihenkilö"));
     fireEvent.click(screen.getByLabelText("Poista Joku Esihenkilö"));
     expect(
@@ -274,7 +274,7 @@ describe("PersonForm", () => {
     await waitFor(() =>
       expect(screen.getByRole("option", { name: "IT" })).toBeInTheDocument(),
     );
-    fireEvent.focus(screen.getByLabelText("Esihenkilö(t):"));
+    fireEvent.focus(screen.getByLabelText("Esihenkilö(t)"));
     expect(screen.getByText("Joku Esihenkilö")).toBeInTheDocument();
     fireEvent.mouseDown(screen.getByRole("button", { name: "outside" }));
     expect(screen.queryByText("Joku Esihenkilö")).not.toBeInTheDocument();
@@ -296,12 +296,12 @@ describe("PersonForm", () => {
 
   it("shows existing person search input", () => {
     render(<PersonForm {...defaultProps} />);
-    expect(screen.getByLabelText("Hae henkilö:")).toBeInTheDocument();
+    expect(screen.getByLabelText("Nimi")).toBeInTheDocument();
   });
 
   it("filters existing people by name when typing in search", async () => {
     render(<PersonForm {...defaultProps} />);
-    const searchInput = screen.getByLabelText("Hae henkilö:");
+    const searchInput = screen.getByLabelText("Nimi");
     fireEvent.focus(searchInput);
     fireEvent.change(searchInput, { target: { value: "Joku" } });
     await waitFor(() => {
@@ -312,7 +312,7 @@ describe("PersonForm", () => {
 
   it("shows 'Ei tuloksia' when search matches no people", async () => {
     render(<PersonForm {...defaultProps} />);
-    const searchInput = screen.getByLabelText("Hae henkilö:");
+    const searchInput = screen.getByLabelText("Nimi");
     fireEvent.focus(searchInput);
     fireEvent.change(searchInput, { target: { value: "zzznomatch" } });
     await waitFor(() => {
@@ -322,7 +322,7 @@ describe("PersonForm", () => {
 
   it("populates form fields when existing person is selected", async () => {
     render(<PersonForm {...defaultProps} />);
-    const searchInput = screen.getByLabelText("Hae henkilö:");
+    const searchInput = screen.getByLabelText("Nimi");
     fireEvent.focus(searchInput);
     fireEvent.change(searchInput, { target: { value: "Joku" } });
     await waitFor(() => {
@@ -337,7 +337,7 @@ describe("PersonForm", () => {
 
   it("disables person detail fields when existing person is selected", async () => {
     render(<PersonForm {...defaultProps} />);
-    const searchInput = screen.getByLabelText("Hae henkilö:");
+    const searchInput = screen.getByLabelText("Nimi");
     fireEvent.focus(searchInput);
     fireEvent.change(searchInput, { target: { value: "Joku" } });
     await waitFor(() => {
@@ -345,18 +345,18 @@ describe("PersonForm", () => {
     });
     fireEvent.click(screen.getByText("Joku Esihenkilö"));
     await waitFor(() => {
-      expect(screen.getByLabelText("Etunimi:")).toBeDisabled();
-      expect(screen.getByLabelText("Sukunimi:")).toBeDisabled();
-      expect(screen.getByLabelText("Osasto:")).toBeDisabled();
-      expect(screen.getByLabelText("Työnimike:")).toBeDisabled();
-      expect(screen.getByLabelText("Tutkimusryhmä:")).toBeDisabled();
-      expect(screen.getByLabelText("Muut tiedot:")).toBeDisabled();
+      expect(screen.getByLabelText("Etunimi")).toBeDisabled();
+      expect(screen.getByLabelText("Sukunimi")).toBeDisabled();
+      expect(screen.getByLabelText("Osasto")).toBeDisabled();
+      expect(screen.getByLabelText("Työnimike")).toBeDisabled();
+      expect(screen.getByLabelText("Tutkimusryhmä")).toBeDisabled();
+      expect(screen.getByLabelText("Muut tiedot")).toBeDisabled();
     });
   });
 
   it("keeps contract date fields editable when existing person is selected", async () => {
     render(<PersonForm {...defaultProps} />);
-    const searchInput = screen.getByLabelText("Hae henkilö:");
+    const searchInput = screen.getByLabelText("Nimi");
     fireEvent.focus(searchInput);
     fireEvent.change(searchInput, { target: { value: "Joku" } });
     await waitFor(() => {
@@ -364,14 +364,14 @@ describe("PersonForm", () => {
     });
     fireEvent.click(screen.getByText("Joku Esihenkilö"));
     await waitFor(() => {
-      expect(screen.getByLabelText("Sopimuksen alku:")).not.toBeDisabled();
-      expect(screen.getByLabelText("Sopimuksen loppu:")).not.toBeDisabled();
+      expect(screen.getByLabelText("Sopimuksen alku")).not.toBeDisabled();
+      expect(screen.getByLabelText("Sopimuksen loppu")).not.toBeDisabled();
     });
   });
 
   it("clears search input after selecting a person", async () => {
     render(<PersonForm {...defaultProps} />);
-    const searchInput = screen.getByLabelText("Hae henkilö:");
+    const searchInput = screen.getByLabelText("Nimi");
     fireEvent.focus(searchInput);
     fireEvent.change(searchInput, { target: { value: "Joku" } });
     await waitFor(() => {

--- a/frontend/tests/components/personModal.test.tsx
+++ b/frontend/tests/components/personModal.test.tsx
@@ -166,10 +166,10 @@ describe("PersonModal", () => {
     await renderAndWait();
     expect(screen.getByRole("button", { name: "Lisää" })).toBeDisabled();
 
-    fireEvent.change(screen.getByRole("textbox", { name: "Etunimi:" }), {
+    fireEvent.change(screen.getByRole("textbox", { name: "Etunimi" }), {
       target: { value: "Terppa" },
     });
-    fireEvent.change(screen.getByRole("textbox", { name: "Sukunimi:" }), {
+    fireEvent.change(screen.getByRole("textbox", { name: "Sukunimi" }), {
       target: { value: "Testaaja" },
     });
     expect(screen.getByRole("button", { name: "Lisää" })).toBeEnabled();

--- a/frontend/tests/components/personModal.test.tsx
+++ b/frontend/tests/components/personModal.test.tsx
@@ -45,8 +45,8 @@ const REQUIRED_INITIAL = {
 
 describe("PersonModal", () => {
   const defaultProps = {
+    onSave: vi.fn(),
     onClose: vi.fn(),
-    onSubmit: vi.fn(),
   };
 
   // Helper that renders and waits for async data fetching to complete
@@ -77,94 +77,101 @@ describe("PersonModal", () => {
 
   it("confirmation button if closing", async () => {
     await renderAndWait();
-    fireEvent.click(screen.getByLabelText("Sulje henkilön lisäys"));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Sulje henkilön lisäys" }),
+    );
     expect(screen.getByText("Sulje ilman tallennusta?")).toBeInTheDocument();
   });
 
-  it("confirmation button if clicking outside", async () => {
+  it("confirmation button if pressing escape", async () => {
     await renderAndWait();
-    const overlay = screen
-      .getByText("Lisää henkilö")
-      .closest(".personmodal-content")!.parentElement!;
-
-    fireEvent.click(overlay);
+    const dialog = screen.getByRole("dialog", { name: "Lisää henkilö" });
+    fireEvent.keyDown(dialog, { key: "Escape" });
 
     expect(screen.getByText("Sulje ilman tallennusta?")).toBeInTheDocument();
   });
 
   it("confirmation button if saving", async () => {
     await renderAndWait({ initial: REQUIRED_INITIAL });
-    fireEvent.click(screen.getByText("Tallenna"));
+    fireEvent.click(screen.getByRole("button", { name: "Tallenna" }));
     expect(screen.getByText("Tallenna muutokset?")).toBeInTheDocument();
   });
 
   it("disables save button if form is invalid", async () => {
     await renderAndWait();
-    const saveButton = screen.getByText("Lisää");
+    const saveButton = screen.getByRole("button", { name: "Lisää" });
     expect(saveButton).toBeDisabled();
   });
 
   it("enables save button if form is valid", async () => {
     await renderAndWait({ initial: REQUIRED_INITIAL });
-    const saveButton = screen.getByText("Tallenna");
+    const saveButton = screen.getByRole("button", { name: "Tallenna" });
     expect(saveButton).toBeEnabled();
   });
 
-  it("calls onSubmit with form data when saving", async () => {
+  it("calls onSave with form data when saving", async () => {
     await renderAndWait({ initial: REQUIRED_INITIAL });
-    fireEvent.click(screen.getByText("Tallenna"));
-    const dialog = screen.getByText("Tallenna muutokset?").closest("div")!;
+    fireEvent.click(screen.getByRole("button", { name: "Tallenna" }));
+    const dialog = await screen.findByRole("alertdialog", {
+      name: "Tallenna muutokset?",
+    });
     fireEvent.click(within(dialog).getByRole("button", { name: "Tallenna" }));
-    expect(defaultProps.onSubmit).toHaveBeenCalledWith(REQUIRED_INITIAL);
+    expect(defaultProps.onSave).toHaveBeenCalledWith(REQUIRED_INITIAL);
   });
 
   it("calls onClose when confirming close", async () => {
     await renderAndWait();
-    fireEvent.click(screen.getByLabelText("Sulje henkilön lisäys"));
-    fireEvent.click(screen.getByText("Kyllä"));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Sulje henkilön lisäys" }),
+    );
+    const dialog = await screen.findByRole("alertdialog", {
+      name: "Sulje ilman tallennusta?",
+    });
+    fireEvent.click(within(dialog).getByRole("button", { name: "Kyllä" }));
     expect(defaultProps.onClose).toHaveBeenCalled();
   });
 
   it("closes confirmation without action on cancel", async () => {
     await renderAndWait();
-    fireEvent.click(screen.getByLabelText("Sulje henkilön lisäys"));
-    fireEvent.click(screen.getByText("Peruuta"));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Sulje henkilön lisäys" }),
+    );
+    const dialog = await screen.findByRole("alertdialog", {
+      name: "Sulje ilman tallennusta?",
+    });
+    fireEvent.click(within(dialog).getByRole("button", { name: "Peruuta" }));
     expect(defaultProps.onClose).not.toHaveBeenCalled();
-    expect(
-      screen.queryByText("Sulje ilman tallennusta?"),
-    ).not.toBeInTheDocument();
+    expect(dialog).not.toHaveAttribute("open");
   });
 
   it("clicking inside the modal does not trigger close confirmation", async () => {
     await renderAndWait();
-    const content = screen
-      .getByText("Lisää henkilö")
-      .closest(".personmodal-content")!;
-    fireEvent.click(content);
-    expect(
-      screen.queryByText("Sulje ilman tallennusta?"),
-    ).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("heading", { name: "Lisää henkilö" }));
+    expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
   });
 
   it("cancel save confirmation does not save or close", async () => {
     await renderAndWait({ initial: REQUIRED_INITIAL });
-    fireEvent.click(screen.getByText("Tallenna"));
-    fireEvent.click(screen.getByText("Peruuta"));
-    expect(defaultProps.onSubmit).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole("button", { name: "Tallenna" }));
+    const dialog = await screen.findByRole("alertdialog", {
+      name: "Tallenna muutokset?",
+    });
+    fireEvent.click(within(dialog).getByRole("button", { name: "Peruuta" }));
+    expect(defaultProps.onSave).not.toHaveBeenCalled();
     expect(defaultProps.onClose).not.toHaveBeenCalled();
-    expect(screen.queryByText("Tallenna muutokset?")).not.toBeInTheDocument();
+    expect(dialog).not.toHaveAttribute("open");
   });
 
   it("enables save button after filling in required fields", async () => {
     await renderAndWait();
-    expect(screen.getByText("Lisää")).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Lisää" })).toBeDisabled();
 
-    fireEvent.change(screen.getByLabelText("Etunimi:"), {
+    fireEvent.change(screen.getByRole("textbox", { name: "Etunimi:" }), {
       target: { value: "Terppa" },
     });
-    fireEvent.change(screen.getByLabelText("Sukunimi:"), {
+    fireEvent.change(screen.getByRole("textbox", { name: "Sukunimi:" }), {
       target: { value: "Testaaja" },
     });
-    expect(screen.getByText("Lisää")).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Lisää" })).toBeEnabled();
   });
 });

--- a/frontend/tests/components/roomForm.test.tsx
+++ b/frontend/tests/components/roomForm.test.tsx
@@ -33,22 +33,22 @@ describe("RoomForm", () => {
 
   it("renders without crashing", () => {
     render(<RoomForm {...defaultProps} />);
-    expect(screen.getByLabelText("Kapasiteetti:")).toBeInTheDocument();
+    expect(screen.getByLabelText("Kapasiteetti")).toBeInTheDocument();
   });
 
   it("renders all fields", () => {
     render(<RoomForm {...defaultProps} />);
-    expect(screen.getByLabelText("Kapasiteetti:")).toBeInTheDocument();
-    expect(screen.getByLabelText("Huonetyyppi:")).toBeInTheDocument();
-    expect(screen.getByLabelText("Osasto:")).toBeInTheDocument();
-    expect(screen.getByLabelText("Lisätiedot:")).toBeInTheDocument();
+    expect(screen.getByLabelText("Kapasiteetti")).toBeInTheDocument();
+    expect(screen.getByLabelText("Huonetyyppi")).toBeInTheDocument();
+    expect(screen.getByLabelText("Osasto")).toBeInTheDocument();
+    expect(screen.getByLabelText("Lisätiedot")).toBeInTheDocument();
   });
 
   it("renders with empty fields by default", () => {
     render(<RoomForm {...defaultProps} />);
-    expect(screen.getByLabelText("Kapasiteetti:")).toHaveValue(null);
-    expect(screen.getByLabelText("Huonetyyppi:")).toHaveValue("");
-    expect(screen.getByLabelText("Osasto:")).toHaveValue("");
+    expect(screen.getByLabelText("Kapasiteetti")).toHaveValue(null);
+    expect(screen.getByLabelText("Huonetyyppi")).toHaveValue("");
+    expect(screen.getByLabelText("Osasto")).toHaveValue("");
   });
 
   it("renders with initial values pre-filled", async () => {
@@ -77,7 +77,7 @@ describe("RoomForm", () => {
 
   it("calls onChange with updated value when capacity changes", () => {
     render(<RoomForm {...defaultProps} initial={INITIAL} />);
-    fireEvent.change(screen.getByLabelText("Kapasiteetti:"), {
+    fireEvent.change(screen.getByLabelText("Kapasiteetti"), {
       target: { value: "20" },
     });
     expect(defaultProps.onChange).toHaveBeenCalledWith(
@@ -93,7 +93,7 @@ describe("RoomForm", () => {
         screen.getByRole("option", { name: "Konferenssihuone" }),
       ).toBeInTheDocument(),
     );
-    fireEvent.change(screen.getByLabelText("Huonetyyppi:"), {
+    fireEvent.change(screen.getByLabelText("Huonetyyppi"), {
       target: { value: "2" },
     });
     expect(defaultProps.onChange).toHaveBeenCalledWith(
@@ -104,7 +104,7 @@ describe("RoomForm", () => {
 
   it("calls onChange with updated value when freeText changes", () => {
     render(<RoomForm {...defaultProps} initial={INITIAL} />);
-    fireEvent.change(screen.getByLabelText("Lisätiedot:"), {
+    fireEvent.change(screen.getByLabelText("Lisätiedot"), {
       target: { value: "Uusi teksti" },
     });
     expect(defaultProps.onChange).toHaveBeenCalledWith(
@@ -126,7 +126,7 @@ describe("RoomForm", () => {
     await waitFor(() =>
       expect(screen.getByRole("option", { name: "HR" })).toBeInTheDocument(),
     );
-    fireEvent.change(screen.getByLabelText("Osasto:"), {
+    fireEvent.change(screen.getByLabelText("Osasto"), {
       target: { value: "2" },
     });
     expect(defaultProps.onChange).toHaveBeenCalledWith(

--- a/frontend/tests/components/roomModal.test.tsx
+++ b/frontend/tests/components/roomModal.test.tsx
@@ -1,13 +1,8 @@
 import RoomModal from "@components/RoomModal/RoomModal";
 import { findAllDepartments } from "@services/referenceDataService.ts";
 import "@testing-library/jest-dom";
-import {
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-  within,
-} from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@services/referenceDataService", () => ({
@@ -30,8 +25,8 @@ const INITIAL = {
 
 describe("RoomModal", () => {
   const defaultProps = {
+    onSave: vi.fn(),
     onClose: vi.fn(),
-    onSubmit: vi.fn(),
     initial: {},
   };
 
@@ -70,68 +65,66 @@ describe("RoomModal", () => {
   });
 
   it("shows confirmation when clicking close button", async () => {
+    const user = userEvent.setup();
     await renderAndWait();
-    fireEvent.click(screen.getByLabelText("Sulje huoneen tietojen muokkaus"));
+    await user.click(screen.getByLabelText("Sulje huoneen tietojen muokkaus"));
     expect(screen.getByText("Sulje ilman tallennusta?")).toBeInTheDocument();
   });
 
   it("shows confirmation when clicking outside the modal", async () => {
+    const user = userEvent.setup();
     await renderAndWait();
-    const overlay = screen
-      .getByText("Muokkaa huonetta")
-      .closest(".roommodal-content")!.parentElement!;
-    fireEvent.click(overlay);
+    const dialog = screen.getByText("Muokkaa huonetta").closest("dialog")!;
+    await user.click(dialog);
     expect(screen.getByText("Sulje ilman tallennusta?")).toBeInTheDocument();
   });
 
   it("shows confirmation when clicking save", async () => {
+    const user = userEvent.setup();
     await renderAndWait({ initial: INITIAL });
-    fireEvent.click(screen.getByText("Tallenna"));
+    await user.click(
+      screen.getByText("Tallenna", { selector: ".room-modal-save-button" }),
+    );
     expect(screen.getByText("Tallenna muutokset?")).toBeInTheDocument();
   });
 
-  it("calls onSubmit with form data when confirming save", async () => {
+  it("calls onSave with form data when confirming save", async () => {
+    const user = userEvent.setup();
     await renderAndWait({ initial: INITIAL });
-    fireEvent.click(screen.getByText("Tallenna"));
-    const dialog = screen.getByText("Tallenna muutokset?").closest("div")!;
-    fireEvent.click(within(dialog).getByRole("button", { name: "Tallenna" }));
-    expect(defaultProps.onSubmit).toHaveBeenCalledWith(INITIAL);
-  });
-
-  it("calls onClose when confirming close", async () => {
-    await renderAndWait();
-    fireEvent.click(screen.getByLabelText("Sulje huoneen tietojen muokkaus"));
-    fireEvent.click(screen.getByText("Kyllä"));
-    expect(defaultProps.onClose).toHaveBeenCalled();
+    await user.click(
+      screen.getByText("Tallenna", { selector: ".room-modal-save-button" }),
+    );
+    const dialog = screen.getByText("Tallenna muutokset?").closest("dialog")!;
+    await user.click(within(dialog).getByRole("button", { name: "Tallenna" }));
+    expect(defaultProps.onSave).toHaveBeenCalledWith(INITIAL);
   });
 
   it("cancelling close confirmation does not close", async () => {
+    const user = userEvent.setup();
     await renderAndWait();
-    fireEvent.click(screen.getByLabelText("Sulje huoneen tietojen muokkaus"));
-    fireEvent.click(screen.getByText("Peruuta"));
+    await user.click(
+      screen.getByRole("button", { name: "Sulje huoneen tietojen muokkaus" }),
+    );
+    const confirmation = screen
+      .getByText("Sulje ilman tallennusta?")
+      .closest("dialog")!;
+    await user.click(screen.getByText("Peruuta"));
     expect(defaultProps.onClose).not.toHaveBeenCalled();
-    expect(
-      screen.queryByText("Sulje ilman tallennusta?"),
-    ).not.toBeInTheDocument();
+    expect(confirmation).not.toHaveAttribute("open");
   });
 
   it("cancelling save confirmation does not save or close", async () => {
+    const user = userEvent.setup();
     await renderAndWait({ initial: INITIAL });
-    fireEvent.click(screen.getByText("Tallenna"));
-    fireEvent.click(screen.getByText("Peruuta"));
-    expect(defaultProps.onSubmit).not.toHaveBeenCalled();
+    await user.click(
+      screen.getByText("Tallenna", { selector: ".room-modal-save-button" }),
+    );
+    const confirmation = screen
+      .getByText("Tallenna muutokset?")
+      .closest("dialog")!;
+    await user.click(screen.getByText("Peruuta"));
+    expect(defaultProps.onSave).not.toHaveBeenCalled();
     expect(defaultProps.onClose).not.toHaveBeenCalled();
-    expect(screen.queryByText("Tallenna muutokset?")).not.toBeInTheDocument();
-  });
-
-  it("clicking inside the modal does not trigger close confirmation", async () => {
-    await renderAndWait();
-    const content = screen
-      .getByText("Muokkaa huonetta")
-      .closest(".roommodal-content")!;
-    fireEvent.click(content);
-    expect(
-      screen.queryByText("Sulje ilman tallennusta?"),
-    ).not.toBeInTheDocument();
+    expect(confirmation).not.toHaveAttribute("open");
   });
 });

--- a/frontend/tests/components/roomModal.test.tsx
+++ b/frontend/tests/components/roomModal.test.tsx
@@ -82,18 +82,14 @@ describe("RoomModal", () => {
   it("shows confirmation when clicking save", async () => {
     const user = userEvent.setup();
     await renderAndWait({ initial: INITIAL });
-    await user.click(
-      screen.getByText("Tallenna", { selector: ".room-modal-save-button" }),
-    );
+    await user.click(screen.getByRole("button", { name: "Tallenna" }));
     expect(screen.getByText("Tallenna muutokset?")).toBeInTheDocument();
   });
 
   it("calls onSave with form data when confirming save", async () => {
     const user = userEvent.setup();
     await renderAndWait({ initial: INITIAL });
-    await user.click(
-      screen.getByText("Tallenna", { selector: ".room-modal-save-button" }),
-    );
+    await user.click(screen.getByRole("button", { name: "Tallenna" }));
     const dialog = screen.getByText("Tallenna muutokset?").closest("dialog")!;
     await user.click(within(dialog).getByRole("button", { name: "Tallenna" }));
     expect(defaultProps.onSave).toHaveBeenCalledWith(INITIAL);
@@ -108,7 +104,9 @@ describe("RoomModal", () => {
     const confirmation = screen
       .getByText("Sulje ilman tallennusta?")
       .closest("dialog")!;
-    await user.click(screen.getByText("Peruuta"));
+    await user.click(
+      within(confirmation).getByRole("button", { name: "Peruuta" }),
+    );
     expect(defaultProps.onClose).not.toHaveBeenCalled();
     expect(confirmation).not.toHaveAttribute("open");
   });
@@ -116,13 +114,13 @@ describe("RoomModal", () => {
   it("cancelling save confirmation does not save or close", async () => {
     const user = userEvent.setup();
     await renderAndWait({ initial: INITIAL });
-    await user.click(
-      screen.getByText("Tallenna", { selector: ".room-modal-save-button" }),
-    );
+    await user.click(screen.getByRole("button", { name: "Tallenna" }));
     const confirmation = screen
       .getByText("Tallenna muutokset?")
       .closest("dialog")!;
-    await user.click(screen.getByText("Peruuta"));
+    await user.click(
+      within(confirmation).getByRole("button", { name: "Peruuta" }),
+    );
     expect(defaultProps.onSave).not.toHaveBeenCalled();
     expect(defaultProps.onClose).not.toHaveBeenCalled();
     expect(confirmation).not.toHaveAttribute("open");

--- a/frontend/tests/components/settingsModal.test.tsx
+++ b/frontend/tests/components/settingsModal.test.tsx
@@ -2,59 +2,55 @@ import SettingsModal from "@components/TopBar/SettingsModal/SettingsModal";
 import "@testing-library/jest-dom";
 import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 describe("SettingsModal", () => {
   const mockOnClose = vi.fn();
-  const mockSetFontSize = vi.fn();
 
   beforeEach(() => {
     mockOnClose.mockClear();
-    mockSetFontSize.mockClear();
+  });
+
+  afterEach(() => {
+    localStorage.removeItem("font-size-map");
+    document.documentElement.style.removeProperty("--font-size-map");
   });
 
   it("renders without crashing", () => {
-    render(
-      <SettingsModal onClose={() => {}} fontSize={16} setFontSize={() => {}} />,
-    );
-    expect(screen.getByText("Asetukset")).toBeInTheDocument();
+    render(<SettingsModal isOpen={true} onClose={() => {}} />);
+    expect(
+      screen.getByRole("heading", { name: "Asetukset" }),
+    ).toBeInTheDocument();
   });
 
   it("calls onClose when close button is clicked", async () => {
-    render(
-      <SettingsModal
-        onClose={mockOnClose}
-        fontSize={24}
-        setFontSize={() => {}}
-      />,
-    );
-    await userEvent.click(
-      screen.getByRole("button", { name: "Sulje asetukset" }),
-    );
+    const user = userEvent.setup();
+    render(<SettingsModal isOpen={true} onClose={mockOnClose} />);
+    await user.click(screen.getByRole("button", { name: "Sulje asetukset" }));
 
     expect(mockOnClose).toHaveBeenCalledTimes(1);
   });
 
   it("displays the correct font size", () => {
-    render(
-      <SettingsModal onClose={() => {}} fontSize={18} setFontSize={() => {}} />,
+    const getItemSpy = vi
+      .spyOn(localStorage, "getItem")
+      .mockImplementation((key) => (key === "font-size-map" ? "18" : null));
+    render(<SettingsModal isOpen={true} onClose={() => {}} />);
+    expect(screen.getByText(/Kartan tekstin fonttikoko:/i)).toHaveTextContent(
+      "18",
     );
-    expect(
-      screen.getByText("Kartan tekstin fonttikoko: 18px"),
-    ).toBeInTheDocument();
+    getItemSpy.mockRestore();
   });
 
-  it("calls setFontSize when the range input value changes", () => {
-    render(
-      <SettingsModal
-        onClose={() => {}}
-        fontSize={16}
-        setFontSize={mockSetFontSize}
-      />,
-    );
-    const rangeInput = screen.getByRole("slider");
+  it("updates the label when the range input value changes", () => {
+    render(<SettingsModal isOpen={true} onClose={() => {}} />);
+    const rangeInput = screen.getByRole("slider", {
+      name: /Kartan tekstin fonttikoko:/i,
+    });
     fireEvent.change(rangeInput, { target: { value: "20" } });
-    expect(mockSetFontSize).toHaveBeenCalledWith(20);
+    expect(screen.getByText(/Kartan tekstin fonttikoko:/i)).toHaveTextContent(
+      "20",
+    );
   });
 
   it("updates localStorage and CSS variable when font size changes", () => {
@@ -62,14 +58,10 @@ describe("SettingsModal", () => {
       .spyOn(localStorage, "setItem")
       .mockImplementation(() => undefined);
 
-    render(
-      <SettingsModal
-        onClose={() => {}}
-        fontSize={16}
-        setFontSize={mockSetFontSize}
-      />,
-    );
-    const rangeInput = screen.getByRole("slider");
+    render(<SettingsModal isOpen={true} onClose={() => {}} />);
+    const rangeInput = screen.getByRole("slider", {
+      name: /Kartan tekstin fonttikoko:/i,
+    });
     fireEvent.change(rangeInput, { target: { value: "22" } });
 
     expect(setItemSpy).toHaveBeenCalledWith("font-size-map", "22");

--- a/frontend/tests/components/settingsModal.test.tsx
+++ b/frontend/tests/components/settingsModal.test.tsx
@@ -17,7 +17,7 @@ describe("SettingsModal", () => {
   });
 
   it("renders without crashing", () => {
-    render(<SettingsModal isOpen={true} onClose={() => {}} />);
+    render(<SettingsModal onClose={() => {}} />);
     expect(
       screen.getByRole("heading", { name: "Asetukset" }),
     ).toBeInTheDocument();
@@ -25,7 +25,7 @@ describe("SettingsModal", () => {
 
   it("calls onClose when close button is clicked", async () => {
     const user = userEvent.setup();
-    render(<SettingsModal isOpen={true} onClose={mockOnClose} />);
+    render(<SettingsModal onClose={mockOnClose} />);
     await user.click(screen.getByRole("button", { name: "Sulje asetukset" }));
 
     expect(mockOnClose).toHaveBeenCalledTimes(1);
@@ -35,7 +35,7 @@ describe("SettingsModal", () => {
     const getItemSpy = vi
       .spyOn(localStorage, "getItem")
       .mockImplementation((key) => (key === "font-size-map" ? "18" : null));
-    render(<SettingsModal isOpen={true} onClose={() => {}} />);
+    render(<SettingsModal onClose={() => {}} />);
     expect(screen.getByText(/Kartan tekstin fonttikoko:/i)).toHaveTextContent(
       "18",
     );
@@ -43,7 +43,7 @@ describe("SettingsModal", () => {
   });
 
   it("updates the label when the range input value changes", () => {
-    render(<SettingsModal isOpen={true} onClose={() => {}} />);
+    render(<SettingsModal onClose={() => {}} />);
     const rangeInput = screen.getByRole("slider", {
       name: /Kartan tekstin fonttikoko:/i,
     });
@@ -58,7 +58,7 @@ describe("SettingsModal", () => {
       .spyOn(localStorage, "setItem")
       .mockImplementation(() => undefined);
 
-    render(<SettingsModal isOpen={true} onClose={() => {}} />);
+    render(<SettingsModal onClose={() => {}} />);
     const rangeInput = screen.getByRole("slider", {
       name: /Kartan tekstin fonttikoko:/i,
     });

--- a/frontend/tests/components/sidePanel.test.tsx
+++ b/frontend/tests/components/sidePanel.test.tsx
@@ -125,12 +125,15 @@ describe("RoomInfo", () => {
 
     customRender(<TestDisplay />);
 
-    await user.click(screen.getByTestId("open-room"));
+    await user.click(screen.getByRole("button", { name: "Open room" }));
 
     expect(screen.getByText("63.60 m²")).toBeInTheDocument();
     expect(screen.getByText("15")).toBeInTheDocument();
-    expect(screen.getByText("konferenssihuone")).toBeInTheDocument();
-    expect(screen.getByText("H523 CS")).toBeInTheDocument();
+    const roomDetails = document.querySelector<HTMLElement>(".room-details");
+    expect(roomDetails).not.toBeNull();
+    const details = within(roomDetails!);
+    expect(details.getByText("konferenssihuone")).toBeInTheDocument();
+    expect(details.getByText("H523 CS")).toBeInTheDocument();
     expect(screen.getByText("Hätäpoistumistie")).toBeInTheDocument();
   });
 
@@ -139,7 +142,7 @@ describe("RoomInfo", () => {
 
     customRender(<TestDisplay />);
 
-    await user.click(screen.getByTestId("open-room"));
+    await user.click(screen.getByRole("button", { name: "Open room" }));
     await user.click(
       screen.getByRole("button", { name: "Muokkaa huoneen tietoja" }),
     );
@@ -150,7 +153,12 @@ describe("RoomInfo", () => {
       screen.getByRole("combobox", { name: "Huonetyyppi:" }),
     ).toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: "Tallenna" }));
+    const roomModal = await screen.findByRole("dialog", {
+      name: "Muokkaa huonetta",
+    });
+    await user.click(
+      within(roomModal).getByRole("button", { name: "Tallenna" }),
+    );
 
     const confirm = await screen.findByRole("alertdialog");
     await user.click(within(confirm).getByRole("button", { name: "Tallenna" }));
@@ -167,26 +175,32 @@ describe("RoomInfo", () => {
     expect(mockOnRoomUpdate).toHaveBeenCalled();
   });
 
-  it.fails("does not close the modal when edit fails", async () => {
+  it("does not close the modal when edit fails", async () => {
     const user = userEvent.setup();
 
     vi.mocked(editRoom).mockRejectedValueOnce(new Error());
 
     customRender(<TestDisplay />);
 
-    await user.click(screen.getByTestId("open-room"));
+    await user.click(screen.getByRole("button", { name: "Open room" }));
     await user.click(
       screen.getByRole("button", { name: "Muokkaa huoneen tietoja" }),
     );
 
-    await user.click(screen.getByRole("button", { name: "Tallenna" }));
+    const roomModal = await screen.findByRole("dialog", {
+      name: "Muokkaa huonetta",
+    });
+
+    await user.click(
+      within(roomModal).getByRole("button", { name: "Tallenna" }),
+    );
 
     const confirm = await screen.findByRole("alertdialog");
     await user.click(within(confirm).getByRole("button", { name: "Tallenna" }));
 
     expect(confirm).not.toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "Tallenna" }),
+      within(roomModal).getByRole("button", { name: "Tallenna" }),
     ).toBeInTheDocument();
   });
 
@@ -199,15 +213,18 @@ describe("RoomPeople", () => {
 
     customRender(<TestDisplay />);
 
-    await user.click(screen.getByTestId("open-room"));
+    await user.click(screen.getByRole("button", { name: "Open room" }));
     await user.click(
       screen.getByRole("button", {
         name: "Sijoita henkilö huoneeseen",
       }),
     );
 
-    await user.type(screen.getByLabelText("Etunimi:"), "Uusi");
-    await user.type(screen.getByLabelText("Sukunimi:"), "Henkilö");
+    await user.type(screen.getByRole("textbox", { name: "Etunimi:" }), "Uusi");
+    await user.type(
+      screen.getByRole("textbox", { name: "Sukunimi:" }),
+      "Henkilö",
+    );
 
     await user.click(screen.getByRole("button", { name: "Lisää" }));
 
@@ -229,17 +246,19 @@ describe("RoomPeople", () => {
 
     customRender(<TestDisplay />);
 
-    await user.click(screen.getByTestId("open-empty-room"));
+    await user.click(screen.getByRole("button", { name: "Open empty room" }));
     await user.click(
       screen.getByRole("button", {
         name: "Sijoita henkilö huoneeseen",
       }),
     );
 
-    const searchInput = screen.getByLabelText("Hae henkilö:");
+    const searchInput = screen.getByRole("textbox", { name: "Hae henkilö:" });
     await user.type(searchInput, "Matti");
-    await screen.findByText("Matti Virtanen");
-    await user.click(screen.getByText("Matti Virtanen"));
+    const listbox = await screen.findByRole("listbox");
+    await user.click(
+      within(listbox).getByRole("option", { name: "Matti Virtanen" }),
+    );
 
     await user.click(screen.getByRole("button", { name: "Lisää" }));
 
@@ -255,30 +274,36 @@ describe("RoomPeople", () => {
     expect(addPerson).not.toHaveBeenCalled();
   });
 
-  it.fails("does not close the modal when adding fails", async () => {
+  it("does not close the modal when adding fails", async () => {
     const user = userEvent.setup();
 
     vi.mocked(addPerson).mockRejectedValueOnce(new Error());
 
     customRender(<TestDisplay />);
 
-    await user.click(screen.getByTestId("open-room"));
+    await user.click(screen.getByRole("button", { name: "Open room" }));
     await user.click(
       screen.getByRole("button", {
         name: "Sijoita henkilö huoneeseen",
       }),
     );
 
-    await user.type(screen.getByLabelText("Etunimi:"), "Uusi");
-    await user.type(screen.getByLabelText("Sukunimi:"), "Henkilö");
+    await user.type(screen.getByRole("textbox", { name: "Etunimi:" }), "Uusi");
+    await user.type(
+      screen.getByRole("textbox", { name: "Sukunimi:" }),
+      "Henkilö",
+    );
 
     await user.click(screen.getByRole("button", { name: "Lisää" }));
 
     const confirm = await screen.findByRole("alertdialog");
     await user.click(within(confirm).getByRole("button", { name: "Tallenna" }));
 
-    expect(confirm).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Lisää" })).toBeInTheDocument();
+    expect(confirm).not.toHaveAttribute("open");
+    const personModal = screen.getByRole("dialog", { name: "Lisää henkilö" });
+    expect(
+      within(personModal).getByRole("button", { name: "Lisää" }),
+    ).toBeInTheDocument();
   });
 
   it("opens the edit person modal with correct initial values and saves edits", async () => {
@@ -288,7 +313,7 @@ describe("RoomPeople", () => {
 
     customRender(<TestDisplay />);
 
-    await user.click(screen.getByTestId("open-room"));
+    await user.click(screen.getByRole("button", { name: "Open room" }));
 
     const personCard = screen.getByRole("article", { name: "Virtanen Matti" });
     await user.click(
@@ -297,7 +322,13 @@ describe("RoomPeople", () => {
       }),
     );
 
-    await user.click(screen.getByRole("button", { name: "Tallenna" }));
+    const personModal = screen.getByRole("dialog", {
+      name: "Muokkaa henkilöä",
+    });
+
+    await user.click(
+      within(personModal).getByRole("button", { name: "Tallenna" }),
+    );
 
     const confirm = await screen.findByRole("alertdialog");
     await user.click(within(confirm).getByRole("button", { name: "Tallenna" }));
@@ -320,7 +351,7 @@ describe("RoomPeople", () => {
 
     customRender(<TestDisplay />);
 
-    await user.click(screen.getByTestId("open-room"));
+    await user.click(screen.getByRole("button", { name: "Open room" }));
 
     const personCard = screen.getByRole("article", { name: "Virtanen Matti" });
     await user.click(
@@ -331,7 +362,10 @@ describe("RoomPeople", () => {
 
     expect(screen.getByText("Poista Matti Virtanen?")).toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: "Poista" }));
+    const confirm = await screen.findByRole("alertdialog", {
+      name: "Poista Matti Virtanen?",
+    });
+    await user.click(within(confirm).getByRole("button", { name: "Poista" }));
 
     expect(removeContract).toHaveBeenCalledWith(1);
     expect(mockOnRoomUpdate).toHaveBeenCalled();
@@ -342,7 +376,7 @@ describe("RoomPeople", () => {
 
     customRender(<TestDisplay />);
 
-    await user.click(screen.getByTestId("open-room"));
+    await user.click(screen.getByRole("button", { name: "Open room" }));
 
     const personCard = screen.getByRole("article", { name: "Virtanen Matti" });
     await user.click(
@@ -352,12 +386,13 @@ describe("RoomPeople", () => {
     );
 
     expect(screen.getByText("Poista Matti Virtanen?")).toBeInTheDocument();
+    const confirm = await screen.findByRole("alertdialog", {
+      name: "Poista Matti Virtanen?",
+    });
 
-    await user.click(screen.getByRole("button", { name: "Peruuta" }));
+    await user.click(within(confirm).getByRole("button", { name: "Peruuta" }));
 
-    expect(
-      screen.queryByText("Poista Matti Virtanen?"),
-    ).not.toBeInTheDocument();
+    expect(confirm).not.toHaveAttribute("open");
     expect(removeContract).not.toHaveBeenCalled();
   });
 
@@ -366,7 +401,7 @@ describe("RoomPeople", () => {
 
     customRender(<TestDisplay />);
 
-    await user.click(screen.getByTestId("open-empty-room"));
+    await user.click(screen.getByRole("button", { name: "Open empty room" }));
     await screen.findByRole("heading", { name: /huone a211/i });
 
     expect(screen.getByText("Ei henkilöitä.")).toBeInTheDocument();
@@ -377,14 +412,19 @@ describe("RoomPeople", () => {
 
     customRender(<TestDisplay />);
 
-    await user.click(screen.getByTestId("open-room-with-person"));
+    await user.click(
+      screen.getByRole("button", { name: "Open room with person" }),
+    );
 
-    await screen.findByText("H516 MATHSTAT");
-    expect(screen.getByText("Osasto")).toBeInTheDocument();
-    expect(screen.getByText("Titteli")).toBeInTheDocument();
-    expect(screen.getByText("Tutkimusryhmä")).toBeInTheDocument();
-    expect(screen.getByText("Esihenkilöt")).toBeInTheDocument();
-    expect(screen.getByText("Tämä on testihenkilö")).toBeInTheDocument();
+    const personCard = screen.getByRole("article", { name: "Virtanen Matti" });
+    await within(personCard).findByText("H516 MATHSTAT");
+    expect(within(personCard).getByText("Osasto")).toBeInTheDocument();
+    expect(within(personCard).getByText("Titteli")).toBeInTheDocument();
+    expect(within(personCard).getByText("Tutkimusryhmä")).toBeInTheDocument();
+    expect(within(personCard).getByText("Esihenkilöt")).toBeInTheDocument();
+    expect(
+      within(personCard).getByText("Tämä on testihenkilö"),
+    ).toBeInTheDocument();
   });
 
   it.todo("shows an error message when editing fails");

--- a/frontend/tests/components/sidePanel.test.tsx
+++ b/frontend/tests/components/sidePanel.test.tsx
@@ -150,7 +150,7 @@ describe("RoomInfo", () => {
     expect(screen.getByText("Muokkaa huonetta")).toBeInTheDocument();
     expect(screen.getByDisplayValue("15")).toBeInTheDocument();
     expect(
-      screen.getByRole("combobox", { name: "Huonetyyppi:" }),
+      screen.getByRole("combobox", { name: "Huonetyyppi" }),
     ).toBeInTheDocument();
 
     const roomModal = await screen.findByRole("dialog", {
@@ -220,9 +220,9 @@ describe("RoomPeople", () => {
       }),
     );
 
-    await user.type(screen.getByRole("textbox", { name: "Etunimi:" }), "Uusi");
+    await user.type(screen.getByRole("textbox", { name: "Etunimi" }), "Uusi");
     await user.type(
-      screen.getByRole("textbox", { name: "Sukunimi:" }),
+      screen.getByRole("textbox", { name: "Sukunimi" }),
       "Henkilö",
     );
 
@@ -253,7 +253,7 @@ describe("RoomPeople", () => {
       }),
     );
 
-    const searchInput = screen.getByRole("textbox", { name: "Hae henkilö:" });
+    const searchInput = screen.getByRole("textbox", { name: "Nimi" });
     await user.type(searchInput, "Matti");
     const listbox = await screen.findByRole("listbox");
     await user.click(
@@ -288,9 +288,9 @@ describe("RoomPeople", () => {
       }),
     );
 
-    await user.type(screen.getByRole("textbox", { name: "Etunimi:" }), "Uusi");
+    await user.type(screen.getByRole("textbox", { name: "Etunimi" }), "Uusi");
     await user.type(
-      screen.getByRole("textbox", { name: "Sukunimi:" }),
+      screen.getByRole("textbox", { name: "Sukunimi" }),
       "Henkilö",
     );
 

--- a/frontend/tests/testSetup.ts
+++ b/frontend/tests/testSetup.ts
@@ -9,6 +9,22 @@ afterEach(() => {
   cleanup();
 });
 
+// Polyfill dialog-element (JSDOM `#3294`)
+if (typeof HTMLDialogElement !== "undefined") {
+  if (!HTMLDialogElement.prototype.showModal) {
+    HTMLDialogElement.prototype.showModal = function () {
+      this.setAttribute("open", "");
+    };
+  }
+
+  if (!HTMLDialogElement.prototype.close) {
+    HTMLDialogElement.prototype.close = function () {
+      this.removeAttribute("open");
+      this.dispatchEvent(new Event("close"));
+    };
+  }
+}
+
 const mockLocalStorage = {
   getItem: vi.fn(),
   setItem: vi.fn(),


### PR DESCRIPTION
<!-- Add a description under each heading if applicable, otherwise leave the default. -->

### Description

<!-- Short description of the changes introduced in the PR -->

1. Refactor all of the modal/dialog components to use the HTML native `dialog` element.
2. Refactor all buttons in the app to use a shared button class with optional modifier classes defined in `index.css` using css nesting syntax.
3. Style all modal/dialog elements and associated forms.
4. Prevent RoomModal and PersonModal from closing in case of an error. Currently an error message or loading animation is not implemented.

### Architecture

<!-- What changes are there to the application architecture? -->

1. All modal/dialog elements now use the dialog element.
2. All buttons now use the shared button class and its modifiers.
3. Move the `--font-size-map` local storage handling to the `SettingsModal` component.

### Motive

<!-- What is the motive behind this PR? -->

1. Improve semantics and accessibility.
2. Improve style consistency.
3. Improve style consistency.
4. Do not silently close forms when submitting when there are errors.

### Testing

<!-- Which types of tests have been added? What do they cover? -->

No new tests have been added. Modal/dialog related tests have been updated to support the new implementations.

### Documentation

<!-- What documentation has been added to the GitHub Wiki? -->

No changes.
