### PR TITLE
docs: add Redis ConfigMap example configuration

### DIFF
--- a/manifests/redis-configmap-example
+++ b/manifests/redis-configmap-example
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hytis-redis-config-example
+data:
+  REDIS_PASSWORD: redis-password-here


### PR DESCRIPTION
### Description

Adds `redis-configmap-example` to the manifests directory as a template reference for configuring Redis credentials in OpenShift deployments.

### Architecture

No changes.

### Motive

Provides  a clear example template for setting up Redis ConfigMaps in the OpenShift environment.
### Testing

No changes.

### Documentation

This PR adds the redis-configmap-example file, which serves as inline documentation for Redis configuration setup in the manifests directory.